### PR TITLE
Fix some errors detected by `mypy`

### DIFF
--- a/generator/utils.py
+++ b/generator/utils.py
@@ -141,7 +141,6 @@ class TypesCodeGenerator:
             "import enum",
             "import functools",
             "from typing import Any, Dict, List, Optional, Tuple, Union",
-            "from typing_extensions import TypeAlias",
             "import attrs",
             "from . import validators",
         ]
@@ -527,7 +526,7 @@ class TypesCodeGenerator:
         doc = _get_indented_documentation(type_alias.documentation)
 
         code_lines = [
-            f"{type_alias.name}: TypeAlias = {self._generate_type_name(type_alias.type)}",
+            f"{type_alias.name} = {self._generate_type_name(type_alias.type)}",
             f'"""{doc}"""' if type_alias.documentation else "",
             f"# Since: {_sanitize_comment(type_alias.since)}"
             if type_alias.since

--- a/lsprotocol/converters.py
+++ b/lsprotocol/converters.py
@@ -27,7 +27,7 @@ def resolve_forward_references() -> None:
 
 
 def get_converter(
-    converter: Optional[cattrs.Converter] = cattrs.Converter(),
+    converter: cattrs.Converter = cattrs.Converter(),
 ) -> cattrs.Converter:
     """Adds cattrs hooks for LSP lsp_types to the given converter."""
     resolve_forward_references()
@@ -39,10 +39,8 @@ def get_converter(
 def _register_required_structure_hooks(
     converter: cattrs.Converter,
 ) -> cattrs.Converter:
-    def _lsp_object_hook(
-        object_: Any, type_: type
-    ) -> Union[lsp_types.LSPObject, lsp_types.LSPArray, str, int, float, bool, None]:
-        if not object_:
+    def _lsp_object_hook(object_: Any, type_: type) -> Any:
+        if object_ is None:
             return object_
         else:
             for type_ in [str, bool, int, float, list]:
@@ -165,7 +163,7 @@ def _register_required_structure_hooks(
 
 
 def _register_custom_property_hooks(converter: cattrs.Converter) -> cattrs.Converter:
-    def _to_camel_case(name: str):
+    def _to_camel_case(name: str) -> str:
         # TODO: when min Python becomes >= 3.9, then update this to:
         # `return name.removesuffix("_")`.
         new_name = name[:-1] if name.endswith("_") else name

--- a/lsprotocol/validators.py
+++ b/lsprotocol/validators.py
@@ -2,13 +2,20 @@
 # Licensed under the MIT License.
 
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import attrs
 
 INTEGER_MIN_VALUE = -(2**31)
 INTEGER_MAX_VALUE = 2**31 - 1
 
 
-def integer_validator(instance: Any, attribute: Any, value: Any) -> bool:
+def integer_validator(
+    instance: Any,
+    attribute: "attrs.Attribute[int]",
+    value: Any,
+) -> bool:
     """Validates that integer value belongs in the range expected by LSP."""
     if not isinstance(value, int) or not (
         INTEGER_MIN_VALUE <= value <= INTEGER_MAX_VALUE
@@ -24,7 +31,11 @@ UINTEGER_MIN_VALUE = 0
 UINTEGER_MAX_VALUE = 2**31 - 1
 
 
-def uinteger_validator(instance: Any, attribute: Any, value: Any) -> bool:
+def uinteger_validator(
+    instance: Any,
+    attribute: "attrs.Attribute[int]",
+    value: Any,
+) -> bool:
     """Validates that unsigned integer value belongs in the range expected by
     LSP."""
     if not isinstance(value, int) or not (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,13 @@ exclude = [
   "SUPPORT.md",
 ]
 
-
+[tool.mypy]
+files = "lsprotocol"
+show_error_codes = true
+strict = true
+enable_error_code = [
+    "ignore-without-code",
+    "redundant-expr",
+    "truthy-bool",
+]
+enable_recursive_aliases = true


### PR DESCRIPTION
picking off quite a few typechecking errors.

Some remarks

- I haven't committed the re-generated code
  - when I regenerate, several hooks go missing (the same happens on main)
  - perhaps you have a set of manual changes that you apply to the autogenerated code?

- I believe that `enable_recursive_aliases` will soon be mypy default, so that seems a very reasonable thing to include

- I haven't added `py.typed`, or tried to update your github workflow to run mypy
  - you'll want to do both of those I think: so that others can take advantage of these types, and so that they don't regress

remaining errors are as follows:

```
lsprotocol/types.py:5136: error: Name "kind" already defined on line 5130  [no-redef]
lsprotocol/types.py:5162: error: Name "kind" already defined on line 5153  [no-redef]
lsprotocol/types.py:5185: error: Name "kind" already defined on line 5179  [no-redef]
lsprotocol/types.py:12070: error: Dict entry 82 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12076: error: Dict entry 88 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12114: error: Dict entry 126 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12116: error: Dict entry 128 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12183: error: Dict entry 195 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12213: error: Dict entry 225 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12226: error: Dict entry 238 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12241: error: Dict entry 253 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12268: error: Dict entry 280 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12291: error: Dict entry 303 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12298: error: Dict entry 310 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12389: error: Dict entry 401 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12411: error: Dict entry 423 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/types.py:12534: error: Dict entry 546 has incompatible type "str": "object"; expected "str": "type"  [dict-item]
lsprotocol/converters.py:122: error: Name "LSPAny" is not defined  [name-defined]
```

where

- the first group look to me as though they might represent a real bug, probably you should look into that
- the second group are I think a mypy error, possibly https://github.com/python/mypy/issues/13810 or similar
  - probably these just want ignoring?
- the final one would be easy to fix - use `lsp_types.LSPAny` - but doing that for some reason causes test breakage
  - seems like there's something screwy here, again you might want to look into it
  - though perhaps the unusual treatment of `"LspAny"` in this piece of code suggests you already know that something's up