### PR TITLE
Add Sphinx documentation site?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 out
 dist
+docs/_build
 .venv*/
 .nox/
 **/__pycache__

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,49 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../"))
+
+from sphinx.application import Sphinx
+
+
+project = 'lsprotocol'
+author = 'Microsoft Corporation'
+copyright = f'2022, {author}'
+release = '2022.0.0a9'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx"
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+}
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+
+
+def process_docstring(app: Sphinx, what: str, name, obj, options, lines):
+
+    for i, line in enumerate(lines):
+        if '@since' in line:
+            lines[i] = line.replace("@since", ".. versionadded:: ")
+
+
+def setup(app: Sphinx):
+    app.connect('autodoc-process-docstring', process_docstring)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,11 @@
+Language Server Protocol implementation for Python
+==================================================
+
+`lsprotocol` is a python implementation of object types used in the Language Server Protocol (LSP).
+
+
+.. toctree::
+   :maxdepth: 2
+
+   overview
+   reference

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,0 +1,47 @@
+Overview
+========
+
+LSP is used by editors to communicate with various tools to enables services like code completion, documentation on hover, formatting, code analysis, etc.
+The intent of this library is to allow you to build on top of the types used by LSP. This repository will be kept up to date with the latest version of LSP as it is updated.
+
+Installation
+-------------
+
+.. code-block:: console
+
+   python -m pip install lsprotocol
+
+Usage
+-----
+
+Using LSP types
+^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   from lsprotocol import types
+
+   position = types.Position(line=10, character=3)
+
+
+Using built-in type converters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   # test.py
+   import json
+   from lsprotocol import converters, types
+
+   position = types.Position(line=10, character=3)
+   converter = converters.get_converter()
+   print(json.dumps(converter.unstructure(position, unstructure_as=types.Position)))
+
+
+Output:
+
+.. code-block:: console
+
+   > python test.py
+   {"line": 10, "character": 3}
+

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,0 +1,14 @@
+Reference
+=========
+
+Converters
+----------
+
+.. automodule:: lsprotocol.converters
+   :members:
+
+Types
+-----
+
+.. automodule:: lsprotocol.types
+   :members:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,16 @@ def _install_requirements(session: nox.Session):
 
 
 @nox.session()
+def docs(session: nox.Session):
+    """Build documentation for lsprotocol."""
+    session.install("-r", "./requirements.txt")
+    session.install("-r", "./docs/requirements.txt")
+
+    # -Ea to force sphinx to re-read the contents of Python files.
+    session.run("sphinx-build", "-M", "html", "./docs", "./docs/_build", "-Ea")
+
+
+@nox.session()
 def tests(session: nox.Session):
     """Run tests for lsprotocol and generator."""
     _install_requirements(session)


### PR DESCRIPTION
Would you be willing to document this package using Sphinx?

I'm [definitely biased](https://github.com/swyddfa/esbonio) but it would be nice to be able to link to the Python version of the LSP types from places like pygls' documentation, Sphinx's [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#module-sphinx.ext.intersphinx) module would make this really easy, especially when coupled with autodoc.

It would also be possible to use Sphinx to fixup the documentation snippets coming from the LSP spec so that links go somewhere useful and so it formats correctly.  (see `conf.py` for a simple example)

Happy to look at setting up [myst](https://myst-parser.readthedocs.io/en/latest/index.html) if you'd prefer the documentation to be written in Markdown.

Let me know your thoughts, or, feel free to close this. :slightly_smiling_face: