### PR TITLE
Add `deprecated` field to the LSP model and regenerate types.

### DIFF
--- a/generator/lsp.json
+++ b/generator/lsp.json
@@ -53,7 +53,7 @@
                 "kind": "reference",
                 "name": "ImplementationRegistrationOptions"
             },
-            "documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a\nThenable that resolves to such."
+            "documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
         },
         {
             "method": "textDocument/typeDefinition",
@@ -105,7 +105,7 @@
                 "kind": "reference",
                 "name": "TypeDefinitionRegistrationOptions"
             },
-            "documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type [Definition](#Definition) or a\nThenable that resolves to such."
+            "documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
         },
         {
             "method": "workspace/workspaceFolders",
@@ -139,17 +139,8 @@
             },
             "messageDirection": "serverToClient",
             "params": {
-                "kind": "and",
-                "items": [
-                    {
-                        "kind": "reference",
-                        "name": "ConfigurationParams"
-                    },
-                    {
-                        "kind": "reference",
-                        "name": "PartialResultParams"
-                    }
-                ]
+                "kind": "reference",
+                "name": "ConfigurationParams"
             },
             "documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model were the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
         },
@@ -178,7 +169,7 @@
                 "kind": "reference",
                 "name": "DocumentColorRegistrationOptions"
             },
-            "documentation": "A request to list all color symbols found in a given text document. The request's\nparameter is of type [DocumentColorParams](#DocumentColorParams) the\nresponse is of type [ColorInformation[]](#ColorInformation) or a Thenable\nthat resolves to such."
+            "documentation": "A request to list all color symbols found in a given text document. The request's\nparameter is of type {@link DocumentColorParams} the\nresponse is of type {@link ColorInformation ColorInformation[]} or a Thenable\nthat resolves to such."
         },
         {
             "method": "textDocument/colorPresentation",
@@ -214,7 +205,7 @@
                     }
                 ]
             },
-            "documentation": "A request to list all presentation for a color. The request's\nparameter is of type [ColorPresentationParams](#ColorPresentationParams) the\nresponse is of type [ColorInformation[]](#ColorInformation) or a Thenable\nthat resolves to such."
+            "documentation": "A request to list all presentation for a color. The request's\nparameter is of type {@link ColorPresentationParams} the\nresponse is of type {@link ColorInformation ColorInformation[]} or a Thenable\nthat resolves to such."
         },
         {
             "method": "textDocument/foldingRange",
@@ -250,7 +241,7 @@
                 "kind": "reference",
                 "name": "FoldingRangeRegistrationOptions"
             },
-            "documentation": "A request to provide folding ranges in a document. The request's\nparameter is of type [FoldingRangeParams](#FoldingRangeParams), the\nresponse is of type [FoldingRangeList](#FoldingRangeList) or a Thenable\nthat resolves to such."
+            "documentation": "A request to provide folding ranges in a document. The request's\nparameter is of type {@link FoldingRangeParams}, the\nresponse is of type {@link FoldingRangeList} or a Thenable\nthat resolves to such."
         },
         {
             "method": "textDocument/declaration",
@@ -302,7 +293,7 @@
                 "kind": "reference",
                 "name": "DeclarationRegistrationOptions"
             },
-            "documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type [Declaration](#Declaration)\nor a typed array of [DeclarationLink](#DeclarationLink) or a Thenable that resolves\nto such."
+            "documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Declaration}\nor a typed array of {@link DeclarationLink} or a Thenable that resolves\nto such."
         },
         {
             "method": "textDocument/selectionRange",
@@ -338,7 +329,7 @@
                 "kind": "reference",
                 "name": "SelectionRangeRegistrationOptions"
             },
-            "documentation": "A request to provide selection ranges in a document. The request's\nparameter is of type [SelectionRangeParams](#SelectionRangeParams), the\nresponse is of type [SelectionRange[]](#SelectionRange[]) or a Thenable\nthat resolves to such."
+            "documentation": "A request to provide selection ranges in a document. The request's\nparameter is of type {@link SelectionRangeParams}, the\nresponse is of type {@link SelectionRange SelectionRange[]} or a Thenable\nthat resolves to such."
         },
         {
             "method": "window/workDoneProgress/create",
@@ -560,7 +551,7 @@
                 "kind": "base",
                 "name": "null"
             },
-            "messageDirection": "clientToServer",
+            "messageDirection": "serverToClient",
             "documentation": "@since 3.16.0",
             "since": "3.16.0"
         },
@@ -720,7 +711,7 @@
                 "kind": "reference",
                 "name": "MonikerRegistrationOptions"
             },
-            "documentation": "A request to get the moniker of a symbol at a given text document position.\nThe request parameter is of type [TextDocumentPositionParams](#TextDocumentPositionParams).\nThe response is of type [Moniker[]](#Moniker[]) or `null`."
+            "documentation": "A request to get the moniker of a symbol at a given text document position.\nThe request parameter is of type {@link TextDocumentPositionParams}.\nThe response is of type {@link Moniker Moniker[]} or `null`."
         },
         {
             "method": "textDocument/prepareTypeHierarchy",
@@ -852,7 +843,7 @@
                 "kind": "reference",
                 "name": "InlineValueRegistrationOptions"
             },
-            "documentation": "A request to provide inline values in a document. The request's parameter is of\ntype [InlineValueParams](#InlineValueParams), the response is of type\n[InlineValue[]](#InlineValue[]) or a Thenable that resolves to such.\n\n@since 3.17.0",
+            "documentation": "A request to provide inline values in a document. The request's parameter is of\ntype {@link InlineValueParams}, the response is of type\n{@link InlineValue InlineValue[]} or a Thenable that resolves to such.\n\n@since 3.17.0",
             "since": "3.17.0"
         },
         {
@@ -861,7 +852,7 @@
                 "kind": "base",
                 "name": "null"
             },
-            "messageDirection": "clientToServer",
+            "messageDirection": "serverToClient",
             "documentation": "@since 3.17.0",
             "since": "3.17.0"
         },
@@ -899,7 +890,7 @@
                 "kind": "reference",
                 "name": "InlayHintRegistrationOptions"
             },
-            "documentation": "A request to provide inlay hints in a document. The request's parameter is of\ntype [InlayHintsParams](#InlayHintsParams), the response is of type\n[InlayHint[]](#InlayHint[]) or a Thenable that resolves to such.\n\n@since 3.17.0",
+            "documentation": "A request to provide inlay hints in a document. The request's parameter is of\ntype {@link InlayHintsParams}, the response is of type\n{@link InlayHint InlayHint[]} or a Thenable that resolves to such.\n\n@since 3.17.0",
             "since": "3.17.0"
         },
         {
@@ -913,7 +904,7 @@
                 "kind": "reference",
                 "name": "InlayHint"
             },
-            "documentation": "A request to resolve additional properties for an inlay hint.\nThe request's parameter is of type [InlayHint](#InlayHint), the response is\nof type [InlayHint](#InlayHint) or a Thenable that resolves to such.\n\n@since 3.17.0",
+            "documentation": "A request to resolve additional properties for an inlay hint.\nThe request's parameter is of type {@link InlayHint}, the response is\nof type {@link InlayHint} or a Thenable that resolves to such.\n\n@since 3.17.0",
             "since": "3.17.0"
         },
         {
@@ -922,7 +913,7 @@
                 "kind": "base",
                 "name": "null"
             },
-            "messageDirection": "clientToServer",
+            "messageDirection": "serverToClient",
             "documentation": "@since 3.17.0",
             "since": "3.17.0"
         },
@@ -980,7 +971,7 @@
                 "kind": "base",
                 "name": "null"
             },
-            "messageDirection": "clientToServer",
+            "messageDirection": "serverToClient",
             "documentation": "The diagnostic refresh request definition.\n\n@since 3.17.0",
             "since": "3.17.0"
         },
@@ -1025,7 +1016,7 @@
                 "kind": "reference",
                 "name": "InitializeError"
             },
-            "documentation": "The initialize request is sent from the client to the server.\nIt is sent once as the request after starting up the server.\nThe requests parameter is of type [InitializeParams](#InitializeParams)\nthe response if of type [InitializeResult](#InitializeResult) of a Thenable that\nresolves to such."
+            "documentation": "The initialize request is sent from the client to the server.\nIt is sent once as the request after starting up the server.\nThe requests parameter is of type {@link InitializeParams}\nthe response if of type {@link InitializeResult} of a Thenable that\nresolves to such."
         },
         {
             "method": "shutdown",
@@ -1125,7 +1116,7 @@
                 "kind": "reference",
                 "name": "CompletionRegistrationOptions"
             },
-            "documentation": "Request to request completion at a given text document position. The request's\nparameter is of type [TextDocumentPosition](#TextDocumentPosition) the response\nis of type [CompletionItem[]](#CompletionItem) or [CompletionList](#CompletionList)\nor a Thenable that resolves to such.\n\nThe request can delay the computation of the [`detail`](#CompletionItem.detail)\nand [`documentation`](#CompletionItem.documentation) properties to the `completionItem/resolve`\nrequest. However, properties that are needed for the initial sorting and filtering, like `sortText`,\n`filterText`, `insertText`, and `textEdit`, must not be changed during resolve."
+            "documentation": "Request to request completion at a given text document position. The request's\nparameter is of type {@link TextDocumentPosition} the response\nis of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}\nor a Thenable that resolves to such.\n\nThe request can delay the computation of the {@link CompletionItem.detail `detail`}\nand {@link CompletionItem.documentation `documentation`} properties to the `completionItem/resolve`\nrequest. However, properties that are needed for the initial sorting and filtering, like `sortText`,\n`filterText`, `insertText`, and `textEdit`, must not be changed during resolve."
         },
         {
             "method": "completionItem/resolve",
@@ -1138,7 +1129,7 @@
                 "kind": "reference",
                 "name": "CompletionItem"
             },
-            "documentation": "Request to resolve additional information for a given completion item.The request's\nparameter is of type [CompletionItem](#CompletionItem) the response\nis of type [CompletionItem](#CompletionItem) or a Thenable that resolves to such."
+            "documentation": "Request to resolve additional information for a given completion item.The request's\nparameter is of type {@link CompletionItem} the response\nis of type {@link CompletionItem} or a Thenable that resolves to such."
         },
         {
             "method": "textDocument/hover",
@@ -1164,7 +1155,7 @@
                 "kind": "reference",
                 "name": "HoverRegistrationOptions"
             },
-            "documentation": "Request to request hover information at a given text document position. The request's\nparameter is of type [TextDocumentPosition](#TextDocumentPosition) the response is of\ntype [Hover](#Hover) or a Thenable that resolves to such."
+            "documentation": "Request to request hover information at a given text document position. The request's\nparameter is of type {@link TextDocumentPosition} the response is of\ntype {@link Hover} or a Thenable that resolves to such."
         },
         {
             "method": "textDocument/signatureHelp",
@@ -1241,7 +1232,7 @@
                 "kind": "reference",
                 "name": "DefinitionRegistrationOptions"
             },
-            "documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the response is of either type [Definition](#Definition)\nor a typed array of [DefinitionLink](#DefinitionLink) or a Thenable that resolves\nto such."
+            "documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the response is of either type {@link Definition}\nor a typed array of {@link DefinitionLink} or a Thenable that resolves\nto such."
         },
         {
             "method": "textDocument/references",
@@ -1277,7 +1268,7 @@
                 "kind": "reference",
                 "name": "ReferenceRegistrationOptions"
             },
-            "documentation": "A request to resolve project-wide references for the symbol denoted\nby the given text document position. The request's parameter is of\ntype [ReferenceParams](#ReferenceParams) the response is of type\n[Location[]](#Location) or a Thenable that resolves to such."
+            "documentation": "A request to resolve project-wide references for the symbol denoted\nby the given text document position. The request's parameter is of\ntype {@link ReferenceParams} the response is of type\n{@link Location Location[]} or a Thenable that resolves to such."
         },
         {
             "method": "textDocument/documentHighlight",
@@ -1313,7 +1304,7 @@
                 "kind": "reference",
                 "name": "DocumentHighlightRegistrationOptions"
             },
-            "documentation": "Request to resolve a [DocumentHighlight](#DocumentHighlight) for a given\ntext document position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the request response is of type [DocumentHighlight[]]\n(#DocumentHighlight) or a Thenable that resolves to such."
+            "documentation": "Request to resolve a {@link DocumentHighlight} for a given\ntext document position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the request response is of type [DocumentHighlight[]]\n(#DocumentHighlight) or a Thenable that resolves to such."
         },
         {
             "method": "textDocument/documentSymbol",
@@ -1368,7 +1359,7 @@
                 "kind": "reference",
                 "name": "DocumentSymbolRegistrationOptions"
             },
-            "documentation": "A request to list all symbols found in a given text document. The request's\nparameter is of type [TextDocumentIdentifier](#TextDocumentIdentifier) the\nresponse is of type [SymbolInformation[]](#SymbolInformation) or a Thenable\nthat resolves to such."
+            "documentation": "A request to list all symbols found in a given text document. The request's\nparameter is of type {@link TextDocumentIdentifier} the\nresponse is of type {@link SymbolInformation SymbolInformation[]} or a Thenable\nthat resolves to such."
         },
         {
             "method": "textDocument/codeAction",
@@ -1435,7 +1426,7 @@
                 "kind": "reference",
                 "name": "CodeAction"
             },
-            "documentation": "Request to resolve additional information for a given code action.The request's\nparameter is of type [CodeAction](#CodeAction) the response\nis of type [CodeAction](#CodeAction) or a Thenable that resolves to such."
+            "documentation": "Request to resolve additional information for a given code action.The request's\nparameter is of type {@link CodeAction} the response\nis of type {@link CodeAction} or a Thenable that resolves to such."
         },
         {
             "method": "workspace/symbol",
@@ -1490,7 +1481,7 @@
                 "kind": "reference",
                 "name": "WorkspaceSymbolRegistrationOptions"
             },
-            "documentation": "A request to list project-wide symbols matching the query string given\nby the [WorkspaceSymbolParams](#WorkspaceSymbolParams). The response is\nof type [SymbolInformation[]](#SymbolInformation) or a Thenable that\nresolves to such.\n\n@since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients\n need to advertise support for WorkspaceSymbols via the client capability\n `workspace.symbol.resolveSupport`.\n",
+            "documentation": "A request to list project-wide symbols matching the query string given\nby the {@link WorkspaceSymbolParams}. The response is\nof type {@link SymbolInformation SymbolInformation[]} or a Thenable that\nresolves to such.\n\n@since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients\n need to advertise support for WorkspaceSymbols via the client capability\n `workspace.symbol.resolveSupport`.\n",
             "since": "3.17.0 - support for WorkspaceSymbol in the returned data. Clients\nneed to advertise support for WorkspaceSymbols via the client capability\n`workspace.symbol.resolveSupport`."
         },
         {
@@ -1613,7 +1604,7 @@
                 "kind": "reference",
                 "name": "DocumentLink"
             },
-            "documentation": "Request to resolve additional information for a given document link. The request's\nparameter is of type [DocumentLink](#DocumentLink) the response\nis of type [DocumentLink](#DocumentLink) or a Thenable that resolves to such."
+            "documentation": "Request to resolve additional information for a given document link. The request's\nparameter is of type {@link DocumentLink} the response\nis of type {@link DocumentLink} or a Thenable that resolves to such."
         },
         {
             "method": "textDocument/formatting",
@@ -2222,20 +2213,6 @@
             "documentation": "The parameters of a configuration request."
         },
         {
-            "name": "PartialResultParams",
-            "properties": [
-                {
-                    "name": "partialResultToken",
-                    "type": {
-                        "kind": "reference",
-                        "name": "ProgressToken"
-                    },
-                    "optional": true,
-                    "documentation": "An optional token that a server can use to report partial results (e.g. streaming) to\nthe client."
-                }
-            ]
-        },
-        {
             "name": "DocumentColorParams",
             "properties": [
                 {
@@ -2257,7 +2234,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "Parameters for a [DocumentColorRequest](#DocumentColorRequest)."
+            "documentation": "Parameters for a {@link DocumentColorRequest}."
         },
         {
             "name": "ColorInformation",
@@ -2339,7 +2316,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "Parameters for a [ColorPresentationRequest](#ColorPresentationRequest)."
+            "documentation": "Parameters for a {@link ColorPresentationRequest}."
         },
         {
             "name": "ColorPresentation",
@@ -2359,7 +2336,7 @@
                         "name": "TextEdit"
                     },
                     "optional": true,
-                    "documentation": "An [edit](#TextEdit) which is applied to a document when selecting\nthis presentation for the color.  When `falsy` the [label](#ColorPresentation.label)\nis used."
+                    "documentation": "An {@link TextEdit edit} which is applied to a document when selecting\nthis presentation for the color.  When `falsy` the {@link ColorPresentation.label label}\nis used."
                 },
                 {
                     "name": "additionalTextEdits",
@@ -2371,7 +2348,7 @@
                         }
                     },
                     "optional": true,
-                    "documentation": "An optional array of additional [text edits](#TextEdit) that are applied when\nselecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves."
+                    "documentation": "An optional array of additional {@link TextEdit text edits} that are applied when\nselecting this color presentation. Edits must not overlap with the main {@link ColorPresentation.textEdit edit} nor with themselves."
                 }
             ]
         },
@@ -2433,7 +2410,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "Parameters for a [FoldingRangeRequest](#FoldingRangeRequest)."
+            "documentation": "Parameters for a {@link FoldingRangeRequest}."
         },
         {
             "name": "FoldingRange",
@@ -2479,7 +2456,7 @@
                         "name": "FoldingRangeKind"
                     },
                     "optional": true,
-                    "documentation": "Describes the kind of the folding range such as `comment' or 'region'. The kind\nis used to categorize folding ranges and used by commands like 'Fold all comments'.\nSee [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds."
+                    "documentation": "Describes the kind of the folding range such as `comment' or 'region'. The kind\nis used to categorize folding ranges and used by commands like 'Fold all comments'.\nSee {@link FoldingRangeKind} for an enumeration of standardized kinds."
                 },
                 {
                     "name": "collapsedText",
@@ -2598,7 +2575,7 @@
                         "kind": "reference",
                         "name": "Range"
                     },
-                    "documentation": "The [range](#Range) of this selection range."
+                    "documentation": "The {@link Range range} of this selection range."
                 },
                 {
                     "name": "parent",
@@ -2738,7 +2715,7 @@
                         "kind": "reference",
                         "name": "Range"
                     },
-                    "documentation": "The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.\nMust be contained by the [`range`](#CallHierarchyItem.range)."
+                    "documentation": "The range that should be selected and revealed when this symbol is being picked, e.g. the name of a function.\nMust be contained by the {@link CallHierarchyItem.range `range`}."
                 },
                 {
                     "name": "data",
@@ -2819,7 +2796,7 @@
                             "name": "Range"
                         }
                     },
-                    "documentation": "The ranges at which the calls appear. This is relative to the caller\ndenoted by [`this.from`](#CallHierarchyIncomingCall.from)."
+                    "documentation": "The ranges at which the calls appear. This is relative to the caller\ndenoted by {@link CallHierarchyIncomingCall.from `this.from`}."
                 }
             ],
             "documentation": "Represents an incoming call, e.g. a caller of a method or constructor.\n\n@since 3.16.0",
@@ -2869,7 +2846,7 @@
                             "name": "Range"
                         }
                     },
-                    "documentation": "The range at which this item is called. This is the range relative to the caller, e.g the item\npassed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)\nand not [`this.to`](#CallHierarchyOutgoingCall.to)."
+                    "documentation": "The range at which this item is called. This is the range relative to the caller, e.g the item\npassed to {@link CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls `provideCallHierarchyOutgoingCalls`}\nand not {@link CallHierarchyOutgoingCall.to `this.to`}."
                 }
             ],
             "documentation": "Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.\n\n@since 3.16.0",
@@ -3492,7 +3469,7 @@
                         "kind": "reference",
                         "name": "Range"
                     },
-                    "documentation": "The range that should be selected and revealed when this symbol is being\npicked, e.g. the name of a function. Must be contained by the\n[`range`](#TypeHierarchyItem.range)."
+                    "documentation": "The range that should be selected and revealed when this symbol is being\npicked, e.g. the name of a function. Must be contained by the\n{@link TypeHierarchyItem.range `range`}."
                 },
                 {
                     "name": "data",
@@ -4625,7 +4602,8 @@
                         "name": "boolean"
                     },
                     "optional": true,
-                    "documentation": "Indicates if this item is deprecated.\n@deprecated Use `tags` instead."
+                    "documentation": "Indicates if this item is deprecated.\n@deprecated Use `tags` instead.",
+                    "deprecated": "Use `tags` instead."
                 },
                 {
                     "name": "preselect",
@@ -4643,7 +4621,7 @@
                         "name": "string"
                     },
                     "optional": true,
-                    "documentation": "A string that should be used when comparing this item\nwith other items. When `falsy` the [label](#CompletionItem.label)\nis used."
+                    "documentation": "A string that should be used when comparing this item\nwith other items. When `falsy` the {@link CompletionItem.label label}\nis used."
                 },
                 {
                     "name": "filterText",
@@ -4652,7 +4630,7 @@
                         "name": "string"
                     },
                     "optional": true,
-                    "documentation": "A string that should be used when filtering a set of\ncompletion items. When `falsy` the [label](#CompletionItem.label)\nis used."
+                    "documentation": "A string that should be used when filtering a set of\ncompletion items. When `falsy` the {@link CompletionItem.label label}\nis used."
                 },
                 {
                     "name": "insertText",
@@ -4661,7 +4639,7 @@
                         "name": "string"
                     },
                     "optional": true,
-                    "documentation": "A string that should be inserted into a document when selecting\nthis completion. When `falsy` the [label](#CompletionItem.label)\nis used.\n\nThe `insertText` is subject to interpretation by the client side.\nSome tools might not take the string literally. For example\nVS Code when code complete is requested in this example\n`con<cursor position>` and a completion item with an `insertText` of\n`console` is provided it will only insert `sole`. Therefore it is\nrecommended to use `textEdit` instead since it avoids additional client\nside interpretation."
+                    "documentation": "A string that should be inserted into a document when selecting\nthis completion. When `falsy` the {@link CompletionItem.label label}\nis used.\n\nThe `insertText` is subject to interpretation by the client side.\nSome tools might not take the string literally. For example\nVS Code when code complete is requested in this example\n`con<cursor position>` and a completion item with an `insertText` of\n`console` is provided it will only insert `sole`. Therefore it is\nrecommended to use `textEdit` instead since it avoids additional client\nside interpretation."
                 },
                 {
                     "name": "insertTextFormat",
@@ -4698,7 +4676,7 @@
                         ]
                     },
                     "optional": true,
-                    "documentation": "An [edit](#TextEdit) which is applied to a document when selecting\nthis completion. When an edit is provided the value of\n[insertText](#CompletionItem.insertText) is ignored.\n\nMost editors support two different operations when accepting a completion\nitem. One is to insert a completion text and the other is to replace an\nexisting text with a completion text. Since this can usually not be\npredetermined by a server it can report both ranges. Clients need to\nsignal support for `InsertReplaceEdits` via the\n`textDocument.completion.insertReplaceSupport` client capability\nproperty.\n\n*Note 1:* The text edit's range as well as both ranges from an insert\nreplace edit must be a [single line] and they must contain the position\nat which completion has been requested.\n*Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range\nmust be a prefix of the edit's replace range, that means it must be\ncontained and starting at the same position.\n\n@since 3.16.0 additional type `InsertReplaceEdit`",
+                    "documentation": "An {@link TextEdit edit} which is applied to a document when selecting\nthis completion. When an edit is provided the value of\n{@link CompletionItem.insertText insertText} is ignored.\n\nMost editors support two different operations when accepting a completion\nitem. One is to insert a completion text and the other is to replace an\nexisting text with a completion text. Since this can usually not be\npredetermined by a server it can report both ranges. Clients need to\nsignal support for `InsertReplaceEdits` via the\n`textDocument.completion.insertReplaceSupport` client capability\nproperty.\n\n*Note 1:* The text edit's range as well as both ranges from an insert\nreplace edit must be a [single line] and they must contain the position\nat which completion has been requested.\n*Note 2:* If an `InsertReplaceEdit` is returned the edit's insert range\nmust be a prefix of the edit's replace range, that means it must be\ncontained and starting at the same position.\n\n@since 3.16.0 additional type `InsertReplaceEdit`",
                     "since": "3.16.0 additional type `InsertReplaceEdit`"
                 },
                 {
@@ -4721,7 +4699,7 @@
                         }
                     },
                     "optional": true,
-                    "documentation": "An optional array of additional [text edits](#TextEdit) that are applied when\nselecting this completion. Edits must not overlap (including the same insert position)\nwith the main [edit](#CompletionItem.textEdit) nor with themselves.\n\nAdditional text edits should be used to change text unrelated to the current cursor position\n(for example adding an import statement at the top of the file if the completion item will\ninsert an unqualified type)."
+                    "documentation": "An optional array of additional {@link TextEdit text edits} that are applied when\nselecting this completion. Edits must not overlap (including the same insert position)\nwith the main {@link CompletionItem.textEdit edit} nor with themselves.\n\nAdditional text edits should be used to change text unrelated to the current cursor position\n(for example adding an import statement at the top of the file if the completion item will\ninsert an unqualified type)."
                 },
                 {
                     "name": "commitCharacters",
@@ -4742,7 +4720,7 @@
                         "name": "Command"
                     },
                     "optional": true,
-                    "documentation": "An optional [command](#Command) that is executed *after* inserting this completion. *Note* that\nadditional modifications to the current document should be described with the\n[additionalTextEdits](#CompletionItem.additionalTextEdits)-property."
+                    "documentation": "An optional {@link Command command} that is executed *after* inserting this completion. *Note* that\nadditional modifications to the current document should be described with the\n{@link CompletionItem.additionalTextEdits additionalTextEdits}-property."
                 },
                 {
                     "name": "data",
@@ -4751,7 +4729,7 @@
                         "name": "LSPAny"
                     },
                     "optional": true,
-                    "documentation": "A data entry field that is preserved on a completion item between a\n[CompletionRequest](#CompletionRequest) and a [CompletionResolveRequest](#CompletionResolveRequest)."
+                    "documentation": "A data entry field that is preserved on a completion item between a\n{@link CompletionRequest} and a {@link CompletionResolveRequest}."
                 }
             ],
             "documentation": "A completion item represents a text snippet that is\nproposed to complete text that is being typed."
@@ -4871,7 +4849,7 @@
                     "documentation": "The completion items."
                 }
             ],
-            "documentation": "Represents a collection of [completion items](#CompletionItem) to be presented\nin the editor."
+            "documentation": "Represents a collection of {@link CompletionItem completion items} to be presented\nin the editor."
         },
         {
             "name": "CompletionRegistrationOptions",
@@ -4886,7 +4864,7 @@
                     "name": "CompletionOptions"
                 }
             ],
-            "documentation": "Registration options for a [CompletionRequest](#CompletionRequest)."
+            "documentation": "Registration options for a {@link CompletionRequest}."
         },
         {
             "name": "HoverParams",
@@ -4903,7 +4881,7 @@
                     "name": "WorkDoneProgressParams"
                 }
             ],
-            "documentation": "Parameters for a [HoverRequest](#HoverRequest)."
+            "documentation": "Parameters for a {@link HoverRequest}."
         },
         {
             "name": "Hover",
@@ -4957,7 +4935,7 @@
                     "name": "HoverOptions"
                 }
             ],
-            "documentation": "Registration options for a [HoverRequest](#HoverRequest)."
+            "documentation": "Registration options for a {@link HoverRequest}."
         },
         {
             "name": "SignatureHelpParams",
@@ -4985,7 +4963,7 @@
                     "name": "WorkDoneProgressParams"
                 }
             ],
-            "documentation": "Parameters for a [SignatureHelpRequest](#SignatureHelpRequest)."
+            "documentation": "Parameters for a {@link SignatureHelpRequest}."
         },
         {
             "name": "SignatureHelp",
@@ -5035,7 +5013,7 @@
                     "name": "SignatureHelpOptions"
                 }
             ],
-            "documentation": "Registration options for a [SignatureHelpRequest](#SignatureHelpRequest)."
+            "documentation": "Registration options for a {@link SignatureHelpRequest}."
         },
         {
             "name": "DefinitionParams",
@@ -5056,7 +5034,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "Parameters for a [DefinitionRequest](#DefinitionRequest)."
+            "documentation": "Parameters for a {@link DefinitionRequest}."
         },
         {
             "name": "DefinitionRegistrationOptions",
@@ -5071,7 +5049,7 @@
                     "name": "DefinitionOptions"
                 }
             ],
-            "documentation": "Registration options for a [DefinitionRequest](#DefinitionRequest)."
+            "documentation": "Registration options for a {@link DefinitionRequest}."
         },
         {
             "name": "ReferenceParams",
@@ -5100,7 +5078,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "Parameters for a [ReferencesRequest](#ReferencesRequest)."
+            "documentation": "Parameters for a {@link ReferencesRequest}."
         },
         {
             "name": "ReferenceRegistrationOptions",
@@ -5115,7 +5093,7 @@
                     "name": "ReferenceOptions"
                 }
             ],
-            "documentation": "Registration options for a [ReferencesRequest](#ReferencesRequest)."
+            "documentation": "Registration options for a {@link ReferencesRequest}."
         },
         {
             "name": "DocumentHighlightParams",
@@ -5136,7 +5114,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "Parameters for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+            "documentation": "Parameters for a {@link DocumentHighlightRequest}."
         },
         {
             "name": "DocumentHighlight",
@@ -5156,7 +5134,7 @@
                         "name": "DocumentHighlightKind"
                     },
                     "optional": true,
-                    "documentation": "The highlight kind, default is [text](#DocumentHighlightKind.Text)."
+                    "documentation": "The highlight kind, default is {@link DocumentHighlightKind.Text text}."
                 }
             ],
             "documentation": "A document highlight is a range inside a text document which deserves\nspecial attention. Usually a document highlight is visualized by changing\nthe background color of its range."
@@ -5174,7 +5152,7 @@
                     "name": "DocumentHighlightOptions"
                 }
             ],
-            "documentation": "Registration options for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+            "documentation": "Registration options for a {@link DocumentHighlightRequest}."
         },
         {
             "name": "DocumentSymbolParams",
@@ -5198,7 +5176,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "Parameters for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+            "documentation": "Parameters for a {@link DocumentSymbolRequest}."
         },
         {
             "name": "SymbolInformation",
@@ -5210,7 +5188,8 @@
                         "name": "boolean"
                     },
                     "optional": true,
-                    "documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead"
+                    "documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead",
+                    "deprecated": "Use tags instead"
                 },
                 {
                     "name": "location",
@@ -5277,7 +5256,8 @@
                         "name": "boolean"
                     },
                     "optional": true,
-                    "documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead"
+                    "documentation": "Indicates if this symbol is deprecated.\n\n@deprecated Use tags instead",
+                    "deprecated": "Use tags instead"
                 },
                 {
                     "name": "range",
@@ -5323,7 +5303,7 @@
                     "name": "DocumentSymbolOptions"
                 }
             ],
-            "documentation": "Registration options for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+            "documentation": "Registration options for a {@link DocumentSymbolRequest}."
         },
         {
             "name": "CodeActionParams",
@@ -5363,7 +5343,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "The parameters of a [CodeActionRequest](#CodeActionRequest)."
+            "documentation": "The parameters of a {@link CodeActionRequest}."
         },
         {
             "name": "Command",
@@ -5506,7 +5486,7 @@
                     "name": "CodeActionOptions"
                 }
             ],
-            "documentation": "Registration options for a [CodeActionRequest](#CodeActionRequest)."
+            "documentation": "Registration options for a {@link CodeActionRequest}."
         },
         {
             "name": "WorkspaceSymbolParams",
@@ -5530,7 +5510,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "The parameters of a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+            "documentation": "The parameters of a {@link WorkspaceSymbolRequest}."
         },
         {
             "name": "WorkspaceSymbol",
@@ -5590,7 +5570,7 @@
                     "name": "WorkspaceSymbolOptions"
                 }
             ],
-            "documentation": "Registration options for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+            "documentation": "Registration options for a {@link WorkspaceSymbolRequest}."
         },
         {
             "name": "CodeLensParams",
@@ -5614,7 +5594,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "The parameters of a [CodeLensRequest](#CodeLensRequest)."
+            "documentation": "The parameters of a {@link CodeLensRequest}."
         },
         {
             "name": "CodeLens",
@@ -5643,10 +5623,10 @@
                         "name": "LSPAny"
                     },
                     "optional": true,
-                    "documentation": "A data entry field that is preserved on a code lens item between\na [CodeLensRequest](#CodeLensRequest) and a [CodeLensResolveRequest]\n(#CodeLensResolveRequest)"
+                    "documentation": "A data entry field that is preserved on a code lens item between\na {@link CodeLensRequest} and a [CodeLensResolveRequest]\n(#CodeLensResolveRequest)"
                 }
             ],
-            "documentation": "A code lens represents a [command](#Command) that should be shown along with\nsource text, like the number of references, a way to run tests, etc.\n\nA code lens is _unresolved_ when no command is associated to it. For performance\nreasons the creation of a code lens and resolving should be done in two stages."
+            "documentation": "A code lens represents a {@link Command command} that should be shown along with\nsource text, like the number of references, a way to run tests, etc.\n\nA code lens is _unresolved_ when no command is associated to it. For performance\nreasons the creation of a code lens and resolving should be done in two stages."
         },
         {
             "name": "CodeLensRegistrationOptions",
@@ -5661,7 +5641,7 @@
                     "name": "CodeLensOptions"
                 }
             ],
-            "documentation": "Registration options for a [CodeLensRequest](#CodeLensRequest)."
+            "documentation": "Registration options for a {@link CodeLensRequest}."
         },
         {
             "name": "DocumentLinkParams",
@@ -5685,7 +5665,7 @@
                     "name": "PartialResultParams"
                 }
             ],
-            "documentation": "The parameters of a [DocumentLinkRequest](#DocumentLinkRequest)."
+            "documentation": "The parameters of a {@link DocumentLinkRequest}."
         },
         {
             "name": "DocumentLink",
@@ -5742,7 +5722,7 @@
                     "name": "DocumentLinkOptions"
                 }
             ],
-            "documentation": "Registration options for a [DocumentLinkRequest](#DocumentLinkRequest)."
+            "documentation": "Registration options for a {@link DocumentLinkRequest}."
         },
         {
             "name": "DocumentFormattingParams",
@@ -5770,7 +5750,7 @@
                     "name": "WorkDoneProgressParams"
                 }
             ],
-            "documentation": "The parameters of a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+            "documentation": "The parameters of a {@link DocumentFormattingRequest}."
         },
         {
             "name": "DocumentFormattingRegistrationOptions",
@@ -5785,7 +5765,7 @@
                     "name": "DocumentFormattingOptions"
                 }
             ],
-            "documentation": "Registration options for a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+            "documentation": "Registration options for a {@link DocumentFormattingRequest}."
         },
         {
             "name": "DocumentRangeFormattingParams",
@@ -5821,7 +5801,7 @@
                     "name": "WorkDoneProgressParams"
                 }
             ],
-            "documentation": "The parameters of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+            "documentation": "The parameters of a {@link DocumentRangeFormattingRequest}."
         },
         {
             "name": "DocumentRangeFormattingRegistrationOptions",
@@ -5836,7 +5816,7 @@
                     "name": "DocumentRangeFormattingOptions"
                 }
             ],
-            "documentation": "Registration options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+            "documentation": "Registration options for a {@link DocumentRangeFormattingRequest}."
         },
         {
             "name": "DocumentOnTypeFormattingParams",
@@ -5874,7 +5854,7 @@
                     "documentation": "The formatting options."
                 }
             ],
-            "documentation": "The parameters of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+            "documentation": "The parameters of a {@link DocumentOnTypeFormattingRequest}."
         },
         {
             "name": "DocumentOnTypeFormattingRegistrationOptions",
@@ -5889,7 +5869,7 @@
                     "name": "DocumentOnTypeFormattingOptions"
                 }
             ],
-            "documentation": "Registration options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+            "documentation": "Registration options for a {@link DocumentOnTypeFormattingRequest}."
         },
         {
             "name": "RenameParams",
@@ -5916,7 +5896,7 @@
                         "kind": "base",
                         "name": "string"
                     },
-                    "documentation": "The new name of the symbol. If the given name is not valid the\nrequest must return a [ResponseError](#ResponseError) with an\nappropriate message set."
+                    "documentation": "The new name of the symbol. If the given name is not valid the\nrequest must return a {@link ResponseError} with an\nappropriate message set."
                 }
             ],
             "mixins": [
@@ -5925,7 +5905,7 @@
                     "name": "WorkDoneProgressParams"
                 }
             ],
-            "documentation": "The parameters of a [RenameRequest](#RenameRequest)."
+            "documentation": "The parameters of a {@link RenameRequest}."
         },
         {
             "name": "RenameRegistrationOptions",
@@ -5940,7 +5920,7 @@
                     "name": "RenameOptions"
                 }
             ],
-            "documentation": "Registration options for a [RenameRequest](#RenameRequest)."
+            "documentation": "Registration options for a {@link RenameRequest}."
         },
         {
             "name": "PrepareRenameParams",
@@ -5988,7 +5968,7 @@
                     "name": "WorkDoneProgressParams"
                 }
             ],
-            "documentation": "The parameters of a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+            "documentation": "The parameters of a {@link ExecuteCommandRequest}."
         },
         {
             "name": "ExecuteCommandRegistrationOptions",
@@ -5999,7 +5979,7 @@
                     "name": "ExecuteCommandOptions"
                 }
             ],
-            "documentation": "Registration options for a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+            "documentation": "Registration options for a {@link ExecuteCommandRequest}."
         },
         {
             "name": "ApplyWorkspaceEditParams",
@@ -6276,6 +6256,20 @@
             ]
         },
         {
+            "name": "PartialResultParams",
+            "properties": [
+                {
+                    "name": "partialResultToken",
+                    "type": {
+                        "kind": "reference",
+                        "name": "ProgressToken"
+                    },
+                    "optional": true,
+                    "documentation": "An optional token that a server can use to report partial results (e.g. streaming) to\nthe client."
+                }
+            ]
+        },
+        {
             "name": "LocationLink",
             "properties": [
                 {
@@ -6312,7 +6306,7 @@
                     "documentation": "The range that should be selected and revealed when this link is being followed, e.g the name of a function.\nMust be contained by the `targetRange`. See also `DocumentSymbol#range`"
                 }
             ],
-            "documentation": "Represents the connection of two locations. Provides additional metadata over normal [locations](#Location),\nincluding an origin range."
+            "documentation": "Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},\nincluding an origin range."
         },
         {
             "name": "Range",
@@ -7729,7 +7723,8 @@
                         ]
                     },
                     "optional": true,
-                    "documentation": "The rootPath of the workspace. Is null\nif no folder is open.\n\n@deprecated in favour of rootUri."
+                    "documentation": "The rootPath of the workspace. Is null\nif no folder is open.\n\n@deprecated in favour of rootUri.",
+                    "deprecated": "in favour of rootUri."
                 },
                 {
                     "name": "rootUri",
@@ -7746,7 +7741,8 @@
                             }
                         ]
                     },
-                    "documentation": "The rootUri of the workspace. Is null if no\nfolder is open. If both `rootPath` and `rootUri` are set\n`rootUri` wins.\n\n@deprecated in favour of workspaceFolders."
+                    "documentation": "The rootUri of the workspace. Is null if no\nfolder is open. If both `rootPath` and `rootUri` are set\n`rootUri` wins.\n\n@deprecated in favour of workspaceFolders.",
+                    "deprecated": "in favour of workspaceFolders."
                 },
                 {
                     "name": "capabilities",
@@ -7768,25 +7764,8 @@
                 {
                     "name": "trace",
                     "type": {
-                        "kind": "or",
-                        "items": [
-                            {
-                                "kind": "stringLiteral",
-                                "value": "off"
-                            },
-                            {
-                                "kind": "stringLiteral",
-                                "value": "messages"
-                            },
-                            {
-                                "kind": "stringLiteral",
-                                "value": "compact"
-                            },
-                            {
-                                "kind": "stringLiteral",
-                                "value": "verbose"
-                            }
-                        ]
+                        "kind": "reference",
+                        "name": "TraceValues"
                     },
                     "optional": true,
                     "documentation": "The initial trace setting. If omitted trace is disabled ('off')."
@@ -8935,7 +8914,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Server Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest)."
+            "documentation": "Server Capabilities for a {@link SignatureHelpRequest}."
         },
         {
             "name": "DefinitionOptions",
@@ -8946,7 +8925,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Server Capabilities for a [DefinitionRequest](#DefinitionRequest)."
+            "documentation": "Server Capabilities for a {@link DefinitionRequest}."
         },
         {
             "name": "ReferenceContext",
@@ -8982,7 +8961,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Provider options for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+            "documentation": "Provider options for a {@link DocumentHighlightRequest}."
         },
         {
             "name": "BaseSymbolInformation",
@@ -9048,7 +9027,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Provider options for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+            "documentation": "Provider options for a {@link DocumentSymbolRequest}."
         },
         {
             "name": "CodeActionContext",
@@ -9087,7 +9066,7 @@
                     "since": "3.17.0"
                 }
             ],
-            "documentation": "Contains additional diagnostic information about the context in which\na [code action](#CodeActionProvider.provideCodeActions) is run."
+            "documentation": "Contains additional diagnostic information about the context in which\na {@link CodeActionProvider.provideCodeActions code action} is run."
         },
         {
             "name": "CodeActionOptions",
@@ -9121,7 +9100,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Provider options for a [CodeActionRequest](#CodeActionRequest)."
+            "documentation": "Provider options for a {@link CodeActionRequest}."
         },
         {
             "name": "WorkspaceSymbolOptions",
@@ -9143,7 +9122,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Server capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+            "documentation": "Server capabilities for a {@link WorkspaceSymbolRequest}."
         },
         {
             "name": "CodeLensOptions",
@@ -9164,7 +9143,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Code Lens provider options of a [CodeLensRequest](#CodeLensRequest)."
+            "documentation": "Code Lens provider options of a {@link CodeLensRequest}."
         },
         {
             "name": "DocumentLinkOptions",
@@ -9185,7 +9164,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Provider options for a [DocumentLinkRequest](#DocumentLinkRequest)."
+            "documentation": "Provider options for a {@link DocumentLinkRequest}."
         },
         {
             "name": "FormattingOptions",
@@ -9248,7 +9227,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Provider options for a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+            "documentation": "Provider options for a {@link DocumentFormattingRequest}."
         },
         {
             "name": "DocumentRangeFormattingOptions",
@@ -9259,7 +9238,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Provider options for a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+            "documentation": "Provider options for a {@link DocumentRangeFormattingRequest}."
         },
         {
             "name": "DocumentOnTypeFormattingOptions",
@@ -9285,7 +9264,7 @@
                     "documentation": "More trigger characters."
                 }
             ],
-            "documentation": "Provider options for a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+            "documentation": "Provider options for a {@link DocumentOnTypeFormattingRequest}."
         },
         {
             "name": "RenameOptions",
@@ -9307,7 +9286,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "Provider options for a [RenameRequest](#RenameRequest)."
+            "documentation": "Provider options for a {@link RenameRequest}."
         },
         {
             "name": "ExecuteCommandOptions",
@@ -9330,7 +9309,7 @@
                     "name": "WorkDoneProgressOptions"
                 }
             ],
-            "documentation": "The server capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+            "documentation": "The server capabilities of a {@link ExecuteCommandRequest}."
         },
         {
             "name": "SemanticTokensLegend",
@@ -9614,12 +9593,6 @@
                 }
             ],
             "documentation": "An unchanged document diagnostic report for a workspace diagnostic result.\n\n@since 3.17.0",
-            "since": "3.17.0"
-        },
-        {
-            "name": "LSPObject",
-            "properties": [],
-            "documentation": "LSP object definition.\n@since 3.17.0",
             "since": "3.17.0"
         },
         {
@@ -10984,7 +10957,7 @@
                     "since": "3.17.0"
                 }
             ],
-            "documentation": "Client capabilities for a [WorkspaceSymbolRequest](#WorkspaceSymbolRequest)."
+            "documentation": "Client capabilities for a {@link WorkspaceSymbolRequest}."
         },
         {
             "name": "ExecuteCommandClientCapabilities",
@@ -10999,7 +10972,7 @@
                     "documentation": "Execute command supports dynamic registration."
                 }
             ],
-            "documentation": "The client capabilities of a [ExecuteCommandRequest](#ExecuteCommandRequest)."
+            "documentation": "The client capabilities of a {@link ExecuteCommandRequest}."
         },
         {
             "name": "SemanticTokensWorkspaceClientCapabilities",
@@ -11531,7 +11504,7 @@
                     "since": "3.15.0"
                 }
             ],
-            "documentation": "Client Capabilities for a [SignatureHelpRequest](#SignatureHelpRequest)."
+            "documentation": "Client Capabilities for a {@link SignatureHelpRequest}."
         },
         {
             "name": "DeclarationClientCapabilities",
@@ -11581,7 +11554,7 @@
                     "since": "3.14.0"
                 }
             ],
-            "documentation": "Client Capabilities for a [DefinitionRequest](#DefinitionRequest)."
+            "documentation": "Client Capabilities for a {@link DefinitionRequest}."
         },
         {
             "name": "TypeDefinitionClientCapabilities",
@@ -11646,7 +11619,7 @@
                     "documentation": "Whether references supports dynamic registration."
                 }
             ],
-            "documentation": "Client Capabilities for a [ReferencesRequest](#ReferencesRequest)."
+            "documentation": "Client Capabilities for a {@link ReferencesRequest}."
         },
         {
             "name": "DocumentHighlightClientCapabilities",
@@ -11661,7 +11634,7 @@
                     "documentation": "Whether document highlight supports dynamic registration."
                 }
             ],
-            "documentation": "Client Capabilities for a [DocumentHighlightRequest](#DocumentHighlightRequest)."
+            "documentation": "Client Capabilities for a {@link DocumentHighlightRequest}."
         },
         {
             "name": "DocumentSymbolClientCapabilities",
@@ -11743,7 +11716,7 @@
                     "since": "3.16.0"
                 }
             ],
-            "documentation": "Client Capabilities for a [DocumentSymbolRequest](#DocumentSymbolRequest)."
+            "documentation": "Client Capabilities for a {@link DocumentSymbolRequest}."
         },
         {
             "name": "CodeActionClientCapabilities",
@@ -11857,7 +11830,7 @@
                     "since": "3.16.0"
                 }
             ],
-            "documentation": "The Client Capabilities of a [CodeActionRequest](#CodeActionRequest)."
+            "documentation": "The Client Capabilities of a {@link CodeActionRequest}."
         },
         {
             "name": "CodeLensClientCapabilities",
@@ -11872,7 +11845,7 @@
                     "documentation": "Whether code lens supports dynamic registration."
                 }
             ],
-            "documentation": "The client capabilities  of a [CodeLensRequest](#CodeLensRequest)."
+            "documentation": "The client capabilities  of a {@link CodeLensRequest}."
         },
         {
             "name": "DocumentLinkClientCapabilities",
@@ -11897,7 +11870,7 @@
                     "since": "3.15.0"
                 }
             ],
-            "documentation": "The client capabilities of a [DocumentLinkRequest](#DocumentLinkRequest)."
+            "documentation": "The client capabilities of a {@link DocumentLinkRequest}."
         },
         {
             "name": "DocumentColorClientCapabilities",
@@ -11926,7 +11899,7 @@
                     "documentation": "Whether formatting supports dynamic registration."
                 }
             ],
-            "documentation": "Client capabilities of a [DocumentFormattingRequest](#DocumentFormattingRequest)."
+            "documentation": "Client capabilities of a {@link DocumentFormattingRequest}."
         },
         {
             "name": "DocumentRangeFormattingClientCapabilities",
@@ -11941,7 +11914,7 @@
                     "documentation": "Whether range formatting supports dynamic registration."
                 }
             ],
-            "documentation": "Client capabilities of a [DocumentRangeFormattingRequest](#DocumentRangeFormattingRequest)."
+            "documentation": "Client capabilities of a {@link DocumentRangeFormattingRequest}."
         },
         {
             "name": "DocumentOnTypeFormattingClientCapabilities",
@@ -11956,7 +11929,7 @@
                     "documentation": "Whether on type formatting supports dynamic registration."
                 }
             ],
-            "documentation": "Client capabilities of a [DocumentOnTypeFormattingRequest](#DocumentOnTypeFormattingRequest)."
+            "documentation": "Client capabilities of a {@link DocumentOnTypeFormattingRequest}."
         },
         {
             "name": "RenameClientCapabilities",
@@ -13793,7 +13766,7 @@
                     }
                 ]
             },
-            "documentation": "The definition of a symbol represented as one or many [locations](#Location).\nFor most programming languages there is only one location at which a symbol is\ndefined.\n\nServers should prefer returning `DefinitionLink` over `Definition` if supported\nby the client."
+            "documentation": "The definition of a symbol represented as one or many {@link Location locations}.\nFor most programming languages there is only one location at which a symbol is\ndefined.\n\nServers should prefer returning `DefinitionLink` over `Definition` if supported\nby the client."
         },
         {
             "name": "DefinitionLink",
@@ -13801,7 +13774,7 @@
                 "kind": "reference",
                 "name": "LocationLink"
             },
-            "documentation": "Information about where a symbol is defined.\n\nProvides additional metadata over normal [location](#Location) definitions, including the range of\nthe defining symbol"
+            "documentation": "Information about where a symbol is defined.\n\nProvides additional metadata over normal {@link Location location} definitions, including the range of\nthe defining symbol"
         },
         {
             "name": "LSPArray",
@@ -13875,7 +13848,7 @@
                     }
                 ]
             },
-            "documentation": "The declaration of a symbol representation as one or many [locations](#Location)."
+            "documentation": "The declaration of a symbol representation as one or many {@link Location locations}."
         },
         {
             "name": "DeclarationLink",
@@ -13883,7 +13856,7 @@
                 "kind": "reference",
                 "name": "LocationLink"
             },
-            "documentation": "Information about where a symbol is declared.\n\nProvides additional metadata over normal [location](#Location) declarations, including the range of\nthe declaring symbol.\n\nServers should prefer returning `DeclarationLink` over `Declaration` if supported\nby the client."
+            "documentation": "Information about where a symbol is declared.\n\nProvides additional metadata over normal {@link Location location} declarations, including the range of\nthe declaring symbol.\n\nServers should prefer returning `DeclarationLink` over `Declaration` if supported\nby the client."
         },
         {
             "name": "InlineValue",
@@ -13973,6 +13946,18 @@
             }
         },
         {
+            "name": "DocumentSelector",
+            "type": {
+                "kind": "array",
+                "element": {
+                    "kind": "reference",
+                    "name": "DocumentFilter"
+                }
+            },
+            "documentation": "A document selector is the combination of one or many document filters.\n\n@sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;\n\nThe use of a string as a document filter is deprecated @since 3.16.0.",
+            "since": "3.16.0."
+        },
+        {
             "name": "ProgressToken",
             "type": {
                 "kind": "or",
@@ -13987,18 +13972,6 @@
                     }
                 ]
             }
-        },
-        {
-            "name": "DocumentSelector",
-            "type": {
-                "kind": "array",
-                "element": {
-                    "kind": "reference",
-                    "name": "DocumentFilter"
-                }
-            },
-            "documentation": "A document selector is the combination of one or many document filters.\n\n@sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;\n\nThe use of a string as a document filter is deprecated @since 3.16.0.",
-            "since": "3.16.0."
         },
         {
             "name": "ChangeAnnotationIdentifier",
@@ -14114,7 +14087,8 @@
                     }
                 ]
             },
-            "documentation": "MarkedString can be used to render human readable text. It is either a markdown string\nor a code-block that provides a language and a code snippet. The language identifier\nis semantically equal to the optional language identifier in fenced code blocks in GitHub\nissues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting\n\nThe pair of a language and a value is an equivalent to markdown:\n```${language}\n${value}\n```\n\nNote that markdown strings will be sanitized - that means html will be escaped.\n@deprecated use MarkupContent instead."
+            "documentation": "MarkedString can be used to render human readable text. It is either a markdown string\nor a code-block that provides a language and a code snippet. The language identifier\nis semantically equal to the optional language identifier in fenced code blocks in GitHub\nissues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting\n\nThe pair of a language and a value is an equivalent to markdown:\n```${language}\n${value}\n```\n\nNote that markdown strings will be sanitized - that means html will be escaped.\n@deprecated use MarkupContent instead.",
+            "deprecated": "use MarkupContent instead."
         },
         {
             "name": "DocumentFilter",
@@ -14133,6 +14107,22 @@
             },
             "documentation": "A document filter describes a top level text document or\na notebook cell document.\n\n@since 3.17.0 - proposed support for NotebookCellTextDocumentFilter.",
             "since": "3.17.0 - proposed support for NotebookCellTextDocumentFilter."
+        },
+        {
+            "name": "LSPObject",
+            "type": {
+                "kind": "map",
+                "key": {
+                    "kind": "base",
+                    "name": "string"
+                },
+                "value": {
+                    "kind": "reference",
+                    "name": "LSPAny"
+                }
+            },
+            "documentation": "LSP object definition.\n@since 3.17.0",
+            "since": "3.17.0"
         },
         {
             "name": "GlobPattern",
@@ -14176,7 +14166,7 @@
                                         "name": "string"
                                     },
                                     "optional": true,
-                                    "documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+                                    "documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
                                 },
                                 {
                                     "name": "pattern",
@@ -14209,7 +14199,7 @@
                                         "kind": "base",
                                         "name": "string"
                                     },
-                                    "documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+                                    "documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
                                 },
                                 {
                                     "name": "pattern",
@@ -14243,7 +14233,7 @@
                                         "name": "string"
                                     },
                                     "optional": true,
-                                    "documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+                                    "documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
                                 },
                                 {
                                     "name": "pattern",
@@ -14258,7 +14248,7 @@
                     }
                 ]
             },
-            "documentation": "A document filter denotes a document by different properties like\nthe [language](#TextDocument.languageId), the [scheme](#Uri.scheme) of\nits resource, or a glob-pattern that is applied to the [path](#TextDocument.fileName).\n\nGlob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
+            "documentation": "A document filter denotes a document by different properties like\nthe {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of\nits resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.\n\nGlob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
             "since": "3.17.0"
         },
         {
@@ -14285,7 +14275,7 @@
                                         "name": "string"
                                     },
                                     "optional": true,
-                                    "documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+                                    "documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
                                 },
                                 {
                                     "name": "pattern",
@@ -14318,7 +14308,7 @@
                                         "kind": "base",
                                         "name": "string"
                                     },
-                                    "documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+                                    "documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
                                 },
                                 {
                                     "name": "pattern",
@@ -14352,7 +14342,7 @@
                                         "name": "string"
                                     },
                                     "optional": true,
-                                    "documentation": "A Uri [scheme](#Uri.scheme), like `file` or `untitled`."
+                                    "documentation": "A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."
                                 },
                                 {
                                     "name": "pattern",

--- a/generator/lsp.schema.json
+++ b/generator/lsp.schema.json
@@ -1,668 +1,783 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "definitions": {
-        "AndType": {
-            "additionalProperties": false,
-            "description": "Represents an `and`type (e.g. TextDocumentParams & WorkDoneProgressParams`).",
-            "properties": {
-                "items": {
-                    "items": {
-                        "$ref": "#/definitions/Type"
-                    },
-                    "type": "array"
-                },
-                "kind": {
-                    "const": "and",
-                    "type": "string"
-                }
-            },
-            "required": ["kind", "items"],
-            "type": "object"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AndType": {
+      "additionalProperties": false,
+      "description": "Represents an `and`type (e.g. TextDocumentParams & WorkDoneProgressParams`).",
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/definitions/Type"
+          },
+          "type": "array"
         },
-        "ArrayType": {
-            "additionalProperties": false,
-            "description": "Represents an array type (e.g. `TextDocument[]`).",
-            "properties": {
-                "element": {
-                    "$ref": "#/definitions/Type"
-                },
-                "kind": {
-                    "const": "array",
-                    "type": "string"
-                }
-            },
-            "required": ["kind", "element"],
-            "type": "object"
+        "kind": {
+          "const": "and",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "items"
+      ],
+      "type": "object"
+    },
+    "ArrayType": {
+      "additionalProperties": false,
+      "description": "Represents an array type (e.g. `TextDocument[]`).",
+      "properties": {
+        "element": {
+          "$ref": "#/definitions/Type"
         },
-        "BaseType": {
-            "additionalProperties": false,
-            "description": "Represents a base type like `string` or `DocumentUri`.",
-            "properties": {
-                "kind": {
-                    "const": "base",
-                    "type": "string"
-                },
-                "name": {
-                    "$ref": "#/definitions/BaseTypes"
-                }
-            },
-            "required": ["kind", "name"],
-            "type": "object"
+        "kind": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "element"
+      ],
+      "type": "object"
+    },
+    "BaseType": {
+      "additionalProperties": false,
+      "description": "Represents a base type like `string` or `DocumentUri`.",
+      "properties": {
+        "kind": {
+          "const": "base",
+          "type": "string"
         },
-        "BaseTypes": {
-            "enum": [
+        "name": {
+          "$ref": "#/definitions/BaseTypes"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "BaseTypes": {
+      "enum": [
+        "URI",
+        "DocumentUri",
+        "integer",
+        "uinteger",
+        "decimal",
+        "RegExp",
+        "string",
+        "boolean",
+        "null"
+      ],
+      "type": "string"
+    },
+    "BooleanLiteralType": {
+      "additionalProperties": false,
+      "description": "Represents a boolean literal type (e.g. `kind: true`).",
+      "properties": {
+        "kind": {
+          "const": "booleanLiteral",
+          "type": "string"
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object"
+    },
+    "Enumeration": {
+      "additionalProperties": false,
+      "description": "Defines an enumeration.",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the enumeration is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the enumeration.",
+          "type": "string"
+        },
+        "proposed": {
+          "description": "Whether this is a proposed enumeration. If omitted, the enumeration is final.",
+          "type": "boolean"
+        },
+        "since": {
+          "description": "Since when (release number) this enumeration is available. Is undefined if not known.",
+          "type": "string"
+        },
+        "supportsCustomValues": {
+          "description": "Whether the enumeration supports custom values (e.g. values which are not part of the set defined in `values`). If omitted no custom values are supported.",
+          "type": "boolean"
+        },
+        "type": {
+          "$ref": "#/definitions/EnumerationType",
+          "description": "The type of the elements."
+        },
+        "values": {
+          "description": "The enum values.",
+          "items": {
+            "$ref": "#/definitions/EnumerationEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "values"
+      ],
+      "type": "object"
+    },
+    "EnumerationEntry": {
+      "additionalProperties": false,
+      "description": "Defines an enumeration entry.",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the enum entry is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the enum item.",
+          "type": "string"
+        },
+        "proposed": {
+          "description": "Whether this is a proposed enumeration entry. If omitted, the enumeration entry is final.",
+          "type": "boolean"
+        },
+        "since": {
+          "description": "Since when (release number) this enumeration entry is available. Is undefined if not known.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value.",
+          "type": [
+            "string",
+            "number"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "EnumerationType": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "base",
+          "type": "string"
+        },
+        "name": {
+          "enum": [
+            "string",
+            "integer",
+            "uinteger"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "IntegerLiteralType": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "integerLiteral",
+          "description": "Represents an integer literal type (e.g. `kind: 1`).",
+          "type": "string"
+        },
+        "value": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object"
+    },
+    "MapKeyType": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "base",
+              "type": "string"
+            },
+            "name": {
+              "enum": [
                 "URI",
                 "DocumentUri",
-                "integer",
-                "uinteger",
-                "decimal",
-                "RegExp",
                 "string",
-                "boolean",
-                "null"
-            ],
-            "type": "string"
+                "integer"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
         },
-        "BooleanLiteralType": {
-            "additionalProperties": false,
-            "description": "Represents a boolean literal type (e.g. `kind: true`).",
-            "properties": {
-                "kind": {
-                    "const": "booleanLiteral",
-                    "type": "string"
-                },
-                "value": {
-                    "type": "boolean"
-                }
-            },
-            "required": ["kind", "value"],
-            "type": "object"
-        },
-        "Enumeration": {
-            "additionalProperties": false,
-            "description": "Defines an enumeration.",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The name of the enumeration.",
-                    "type": "string"
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed enumeration. If omitted, the enumeration is final.",
-                    "type": "boolean"
-                },
-                "since": {
-                    "description": "Since when (release number) this enumeration is available. Is undefined if not known.",
-                    "type": "string"
-                },
-                "supportsCustomValues": {
-                    "description": "Whether the enumeration supports custom values (e.g. values which are not part of the set defined in `values`). If omitted no custom values are supported.",
-                    "type": "boolean"
-                },
-                "type": {
-                    "$ref": "#/definitions/EnumerationType",
-                    "description": "The type of the elements."
-                },
-                "values": {
-                    "description": "The enum values.",
-                    "items": {
-                        "$ref": "#/definitions/EnumerationEntry"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": ["name", "type", "values"],
-            "type": "object"
-        },
-        "EnumerationEntry": {
-            "additionalProperties": false,
-            "description": "Defines an enumeration entry.",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The name of the enum item.",
-                    "type": "string"
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed enumeration entry. If omitted, the enumeration entry is final.",
-                    "type": "boolean"
-                },
-                "since": {
-                    "description": "Since when (release number) this enumeration entry is available. Is undefined if not known.",
-                    "type": "string"
-                },
-                "value": {
-                    "description": "The value.",
-                    "type": ["string", "number"]
-                }
-            },
-            "required": ["name", "value"],
-            "type": "object"
-        },
-        "EnumerationType": {
-            "additionalProperties": false,
-            "properties": {
-                "kind": {
-                    "const": "base",
-                    "type": "string"
-                },
-                "name": {
-                    "enum": ["string", "integer", "uinteger"],
-                    "type": "string"
-                }
-            },
-            "required": ["kind", "name"],
-            "type": "object"
-        },
-        "IntegerLiteralType": {
-            "additionalProperties": false,
-            "properties": {
-                "kind": {
-                    "const": "integerLiteral",
-                    "description": "Represents an integer literal type (e.g. `kind: 1`).",
-                    "type": "string"
-                },
-                "value": {
-                    "type": "number"
-                }
-            },
-            "required": ["kind", "value"],
-            "type": "object"
-        },
-        "MapKeyType": {
-            "anyOf": [
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "kind": {
-                            "const": "base",
-                            "type": "string"
-                        },
-                        "name": {
-                            "enum": ["URI", "DocumentUri", "string", "integer"],
-                            "type": "string"
-                        }
-                    },
-                    "required": ["kind", "name"],
-                    "type": "object"
-                },
-                {
-                    "$ref": "#/definitions/ReferenceType"
-                }
-            ],
-            "description": "Represents a type that can be used as a key in a map type. If a reference type is used then the type must either resolve to a `string` or `integer` type. (e.g. `type ChangeAnnotationIdentifier === string`)."
-        },
-        "MapType": {
-            "additionalProperties": false,
-            "description": "Represents a JSON object map (e.g. `interface Map<K extends string | integer, V> { [key: K] => V; }`).",
-            "properties": {
-                "key": {
-                    "$ref": "#/definitions/MapKeyType"
-                },
-                "kind": {
-                    "const": "map",
-                    "type": "string"
-                },
-                "value": {
-                    "$ref": "#/definitions/Type"
-                }
-            },
-            "required": ["kind", "key", "value"],
-            "type": "object"
-        },
-        "MessageDirection": {
-            "description": "Indicates in which direction a message is sent in the protocol.",
-            "enum": ["clientToServer", "serverToClient", "both"],
-            "type": "string"
-        },
-        "MetaData": {
-            "additionalProperties": false,
-            "properties": {
-                "version": {
-                    "description": "The protocol version.",
-                    "type": "string"
-                }
-            },
-            "required": ["version"],
-            "type": "object"
-        },
-        "MetaModel": {
-            "additionalProperties": false,
-            "description": "The actual meta model.",
-            "properties": {
-                "enumerations": {
-                    "description": "The enumerations.",
-                    "items": {
-                        "$ref": "#/definitions/Enumeration"
-                    },
-                    "type": "array"
-                },
-                "metaData": {
-                    "$ref": "#/definitions/MetaData",
-                    "description": "Additional meta data."
-                },
-                "notifications": {
-                    "description": "The notifications.",
-                    "items": {
-                        "$ref": "#/definitions/Notification"
-                    },
-                    "type": "array"
-                },
-                "requests": {
-                    "description": "The requests.",
-                    "items": {
-                        "$ref": "#/definitions/Request"
-                    },
-                    "type": "array"
-                },
-                "structures": {
-                    "description": "The structures.",
-                    "items": {
-                        "$ref": "#/definitions/Structure"
-                    },
-                    "type": "array"
-                },
-                "typeAliases": {
-                    "description": "The type aliases.",
-                    "items": {
-                        "$ref": "#/definitions/TypeAlias"
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "metaData",
-                "requests",
-                "notifications",
-                "structures",
-                "enumerations",
-                "typeAliases"
-            ],
-            "type": "object"
-        },
-        "Notification": {
-            "additionalProperties": false,
-            "description": "Represents a LSP notification",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation;",
-                    "type": "string"
-                },
-                "messageDirection": {
-                    "$ref": "#/definitions/MessageDirection",
-                    "description": "The direction in which this notification is sent in the protocol."
-                },
-                "method": {
-                    "description": "The request's method name.",
-                    "type": "string"
-                },
-                "params": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Type"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/definitions/Type"
-                            },
-                            "type": "array"
-                        }
-                    ],
-                    "description": "The parameter type(s) if any."
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed notification. If omitted the notification is final.",
-                    "type": "boolean"
-                },
-                "registrationMethod": {
-                    "description": "Optional a dynamic registration method if it different from the request's method.",
-                    "type": "string"
-                },
-                "registrationOptions": {
-                    "$ref": "#/definitions/Type",
-                    "description": "Optional registration options if the notification supports dynamic registration."
-                },
-                "since": {
-                    "description": "Since when (release number) this notification is available. Is undefined if not known.",
-                    "type": "string"
-                }
-            },
-            "required": ["method", "messageDirection"],
-            "type": "object"
-        },
-        "OrType": {
-            "additionalProperties": false,
-            "description": "Represents an `or` type (e.g. `Location | LocationLink`).",
-            "properties": {
-                "items": {
-                    "items": {
-                        "$ref": "#/definitions/Type"
-                    },
-                    "type": "array"
-                },
-                "kind": {
-                    "const": "or",
-                    "type": "string"
-                }
-            },
-            "required": ["kind", "items"],
-            "type": "object"
-        },
-        "Property": {
-            "additionalProperties": false,
-            "description": "Represents an object property.",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The property name;",
-                    "type": "string"
-                },
-                "optional": {
-                    "description": "Whether the property is optional. If omitted, the property is mandatory.",
-                    "type": "boolean"
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed property. If omitted, the structure is final.",
-                    "type": "boolean"
-                },
-                "since": {
-                    "description": "Since when (release number) this property is available. Is undefined if not known.",
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/Type",
-                    "description": "The type of the property"
-                }
-            },
-            "required": ["name", "type"],
-            "type": "object"
-        },
-        "ReferenceType": {
-            "additionalProperties": false,
-            "description": "Represents a reference to another type (e.g. `TextDocument`). This is either a `Structure`, a `Enumeration` or a `TypeAlias` in the same meta model.",
-            "properties": {
-                "kind": {
-                    "const": "reference",
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            },
-            "required": ["kind", "name"],
-            "type": "object"
-        },
-        "Request": {
-            "additionalProperties": false,
-            "description": "Represents a LSP request",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation;",
-                    "type": "string"
-                },
-                "errorData": {
-                    "$ref": "#/definitions/Type",
-                    "description": "An optional error data type."
-                },
-                "messageDirection": {
-                    "$ref": "#/definitions/MessageDirection",
-                    "description": "The direction in which this request is sent in the protocol."
-                },
-                "method": {
-                    "description": "The request's method name.",
-                    "type": "string"
-                },
-                "params": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Type"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/definitions/Type"
-                            },
-                            "type": "array"
-                        }
-                    ],
-                    "description": "The parameter type(s) if any."
-                },
-                "partialResult": {
-                    "$ref": "#/definitions/Type",
-                    "description": "Optional partial result type if the request supports partial result reporting."
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed feature. If omitted the feature is final.",
-                    "type": "boolean"
-                },
-                "registrationMethod": {
-                    "description": "Optional a dynamic registration method if it different from the request's method.",
-                    "type": "string"
-                },
-                "registrationOptions": {
-                    "$ref": "#/definitions/Type",
-                    "description": "Optional registration options if the request supports dynamic registration."
-                },
-                "result": {
-                    "$ref": "#/definitions/Type",
-                    "description": "The result type."
-                },
-                "since": {
-                    "description": "Since when (release number) this request is available. Is undefined if not known.",
-                    "type": "string"
-                }
-            },
-            "required": ["method", "result", "messageDirection"],
-            "type": "object"
-        },
-        "StringLiteralType": {
-            "additionalProperties": false,
-            "description": "Represents a string literal type (e.g. `kind: 'rename'`).",
-            "properties": {
-                "kind": {
-                    "const": "stringLiteral",
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            },
-            "required": ["kind", "value"],
-            "type": "object"
-        },
-        "Structure": {
-            "additionalProperties": false,
-            "description": "Defines the structure of an object literal.",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation;",
-                    "type": "string"
-                },
-                "extends": {
-                    "description": "Structures extended from. This structures form a polymorphic type hierarchy.",
-                    "items": {
-                        "$ref": "#/definitions/Type"
-                    },
-                    "type": "array"
-                },
-                "mixins": {
-                    "description": "Structures to mix in. The properties of these structures are `copied` into this structure. Mixins don't form a polymorphic type hierarchy in LSP.",
-                    "items": {
-                        "$ref": "#/definitions/Type"
-                    },
-                    "type": "array"
-                },
-                "name": {
-                    "description": "The name of the structure.",
-                    "type": "string"
-                },
-                "properties": {
-                    "description": "The properties.",
-                    "items": {
-                        "$ref": "#/definitions/Property"
-                    },
-                    "type": "array"
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed structure. If omitted, the structure is final.",
-                    "type": "boolean"
-                },
-                "since": {
-                    "description": "Since when (release number) this structure is available. Is undefined if not known.",
-                    "type": "string"
-                }
-            },
-            "required": ["name", "properties"],
-            "type": "object"
-        },
-        "StructureLiteral": {
-            "additionalProperties": false,
-            "description": "Defines a unnamed structure of an object literal.",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation.",
-                    "type": "string"
-                },
-                "properties": {
-                    "description": "The properties.",
-                    "items": {
-                        "$ref": "#/definitions/Property"
-                    },
-                    "type": "array"
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed structure. If omitted, the structure is final.",
-                    "type": "boolean"
-                },
-                "since": {
-                    "description": "Since when (release number) this structure is available. Is undefined if not known.",
-                    "type": "string"
-                }
-            },
-            "required": ["properties"],
-            "type": "object"
-        },
-        "StructureLiteralType": {
-            "additionalProperties": false,
-            "description": "Represents a literal structure (e.g. `property: { start: uinteger; end: uinteger; }`).",
-            "properties": {
-                "kind": {
-                    "const": "literal",
-                    "type": "string"
-                },
-                "value": {
-                    "$ref": "#/definitions/StructureLiteral"
-                }
-            },
-            "required": ["kind", "value"],
-            "type": "object"
-        },
-        "TupleType": {
-            "additionalProperties": false,
-            "description": "Represents a `tuple` type (e.g. `[integer, integer]`).",
-            "properties": {
-                "items": {
-                    "items": {
-                        "$ref": "#/definitions/Type"
-                    },
-                    "type": "array"
-                },
-                "kind": {
-                    "const": "tuple",
-                    "type": "string"
-                }
-            },
-            "required": ["kind", "items"],
-            "type": "object"
-        },
-        "Type": {
-            "anyOf": [
-                {
-                    "$ref": "#/definitions/BaseType"
-                },
-                {
-                    "$ref": "#/definitions/ReferenceType"
-                },
-                {
-                    "$ref": "#/definitions/ArrayType"
-                },
-                {
-                    "$ref": "#/definitions/MapType"
-                },
-                {
-                    "$ref": "#/definitions/AndType"
-                },
-                {
-                    "$ref": "#/definitions/OrType"
-                },
-                {
-                    "$ref": "#/definitions/TupleType"
-                },
-                {
-                    "$ref": "#/definitions/StructureLiteralType"
-                },
-                {
-                    "$ref": "#/definitions/StringLiteralType"
-                },
-                {
-                    "$ref": "#/definitions/IntegerLiteralType"
-                },
-                {
-                    "$ref": "#/definitions/BooleanLiteralType"
-                }
-            ]
-        },
-        "TypeAlias": {
-            "additionalProperties": false,
-            "description": "Defines a type alias. (e.g. `type Definition = Location | LocationLink`)",
-            "properties": {
-                "documentation": {
-                    "description": "An optional documentation.",
-                    "type": "string"
-                },
-                "name": {
-                    "description": "The name of the type alias.",
-                    "type": "string"
-                },
-                "proposed": {
-                    "description": "Whether this is a proposed type alias. If omitted, the type alias is final.",
-                    "type": "boolean"
-                },
-                "since": {
-                    "description": "Since when (release number) this structure is available. Is undefined if not known.",
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/Type",
-                    "description": "The aliased type."
-                }
-            },
-            "required": ["name", "type"],
-            "type": "object"
-        },
-        "TypeKind": {
-            "enum": [
-                "base",
-                "reference",
-                "array",
-                "map",
-                "and",
-                "or",
-                "tuple",
-                "literal",
-                "stringLiteral",
-                "integerLiteral",
-                "booleanLiteral"
-            ],
-            "type": "string"
+        {
+          "$ref": "#/definitions/ReferenceType"
         }
+      ],
+      "description": "Represents a type that can be used as a key in a map type. If a reference type is used then the type must either resolve to a `string` or `integer` type. (e.g. `type ChangeAnnotationIdentifier === string`)."
+    },
+    "MapType": {
+      "additionalProperties": false,
+      "description": "Represents a JSON object map (e.g. `interface Map<K extends string | integer, V> { [key: K] => V; }`).",
+      "properties": {
+        "key": {
+          "$ref": "#/definitions/MapKeyType"
+        },
+        "kind": {
+          "const": "map",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/Type"
+        }
+      },
+      "required": [
+        "kind",
+        "key",
+        "value"
+      ],
+      "type": "object"
+    },
+    "MessageDirection": {
+      "description": "Indicates in which direction a message is sent in the protocol.",
+      "enum": [
+        "clientToServer",
+        "serverToClient",
+        "both"
+      ],
+      "type": "string"
+    },
+    "MetaData": {
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "description": "The protocol version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version"
+      ],
+      "type": "object"
+    },
+    "MetaModel": {
+      "additionalProperties": false,
+      "description": "The actual meta model.",
+      "properties": {
+        "enumerations": {
+          "description": "The enumerations.",
+          "items": {
+            "$ref": "#/definitions/Enumeration"
+          },
+          "type": "array"
+        },
+        "metaData": {
+          "$ref": "#/definitions/MetaData",
+          "description": "Additional meta data."
+        },
+        "notifications": {
+          "description": "The notifications.",
+          "items": {
+            "$ref": "#/definitions/Notification"
+          },
+          "type": "array"
+        },
+        "requests": {
+          "description": "The requests.",
+          "items": {
+            "$ref": "#/definitions/Request"
+          },
+          "type": "array"
+        },
+        "structures": {
+          "description": "The structures.",
+          "items": {
+            "$ref": "#/definitions/Structure"
+          },
+          "type": "array"
+        },
+        "typeAliases": {
+          "description": "The type aliases.",
+          "items": {
+            "$ref": "#/definitions/TypeAlias"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "metaData",
+        "requests",
+        "notifications",
+        "structures",
+        "enumerations",
+        "typeAliases"
+      ],
+      "type": "object"
+    },
+    "Notification": {
+      "additionalProperties": false,
+      "description": "Represents a LSP notification",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the notification is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation;",
+          "type": "string"
+        },
+        "messageDirection": {
+          "$ref": "#/definitions/MessageDirection",
+          "description": "The direction in which this notification is sent in the protocol."
+        },
+        "method": {
+          "description": "The request's method name.",
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Type"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/Type"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "The parameter type(s) if any."
+        },
+        "proposed": {
+          "description": "Whether this is a proposed notification. If omitted the notification is final.",
+          "type": "boolean"
+        },
+        "registrationMethod": {
+          "description": "Optional a dynamic registration method if it different from the request's method.",
+          "type": "string"
+        },
+        "registrationOptions": {
+          "$ref": "#/definitions/Type",
+          "description": "Optional registration options if the notification supports dynamic registration."
+        },
+        "since": {
+          "description": "Since when (release number) this notification is available. Is undefined if not known.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "method",
+        "messageDirection"
+      ],
+      "type": "object"
+    },
+    "OrType": {
+      "additionalProperties": false,
+      "description": "Represents an `or` type (e.g. `Location | LocationLink`).",
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/definitions/Type"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "const": "or",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "items"
+      ],
+      "type": "object"
+    },
+    "Property": {
+      "additionalProperties": false,
+      "description": "Represents an object property.",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the property is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The property name;",
+          "type": "string"
+        },
+        "optional": {
+          "description": "Whether the property is optional. If omitted, the property is mandatory.",
+          "type": "boolean"
+        },
+        "proposed": {
+          "description": "Whether this is a proposed property. If omitted, the structure is final.",
+          "type": "boolean"
+        },
+        "since": {
+          "description": "Since when (release number) this property is available. Is undefined if not known.",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The type of the property"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ReferenceType": {
+      "additionalProperties": false,
+      "description": "Represents a reference to another type (e.g. `TextDocument`). This is either a `Structure`, a `Enumeration` or a `TypeAlias` in the same meta model.",
+      "properties": {
+        "kind": {
+          "const": "reference",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "name"
+      ],
+      "type": "object"
+    },
+    "Request": {
+      "additionalProperties": false,
+      "description": "Represents a LSP request",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the request is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation;",
+          "type": "string"
+        },
+        "errorData": {
+          "$ref": "#/definitions/Type",
+          "description": "An optional error data type."
+        },
+        "messageDirection": {
+          "$ref": "#/definitions/MessageDirection",
+          "description": "The direction in which this request is sent in the protocol."
+        },
+        "method": {
+          "description": "The request's method name.",
+          "type": "string"
+        },
+        "params": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Type"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/Type"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "The parameter type(s) if any."
+        },
+        "partialResult": {
+          "$ref": "#/definitions/Type",
+          "description": "Optional partial result type if the request supports partial result reporting."
+        },
+        "proposed": {
+          "description": "Whether this is a proposed feature. If omitted the feature is final.",
+          "type": "boolean"
+        },
+        "registrationMethod": {
+          "description": "Optional a dynamic registration method if it different from the request's method.",
+          "type": "string"
+        },
+        "registrationOptions": {
+          "$ref": "#/definitions/Type",
+          "description": "Optional registration options if the request supports dynamic registration."
+        },
+        "result": {
+          "$ref": "#/definitions/Type",
+          "description": "The result type."
+        },
+        "since": {
+          "description": "Since when (release number) this request is available. Is undefined if not known.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "method",
+        "result",
+        "messageDirection"
+      ],
+      "type": "object"
+    },
+    "StringLiteralType": {
+      "additionalProperties": false,
+      "description": "Represents a string literal type (e.g. `kind: 'rename'`).",
+      "properties": {
+        "kind": {
+          "const": "stringLiteral",
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object"
+    },
+    "Structure": {
+      "additionalProperties": false,
+      "description": "Defines the structure of an object literal.",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the structure is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation;",
+          "type": "string"
+        },
+        "extends": {
+          "description": "Structures extended from. This structures form a polymorphic type hierarchy.",
+          "items": {
+            "$ref": "#/definitions/Type"
+          },
+          "type": "array"
+        },
+        "mixins": {
+          "description": "Structures to mix in. The properties of these structures are `copied` into this structure. Mixins don't form a polymorphic type hierarchy in LSP.",
+          "items": {
+            "$ref": "#/definitions/Type"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "The name of the structure.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties.",
+          "items": {
+            "$ref": "#/definitions/Property"
+          },
+          "type": "array"
+        },
+        "proposed": {
+          "description": "Whether this is a proposed structure. If omitted, the structure is final.",
+          "type": "boolean"
+        },
+        "since": {
+          "description": "Since when (release number) this structure is available. Is undefined if not known.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "properties"
+      ],
+      "type": "object"
+    },
+    "StructureLiteral": {
+      "additionalProperties": false,
+      "description": "Defines a unnamed structure of an object literal.",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the literal is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation.",
+          "type": "string"
+        },
+        "properties": {
+          "description": "The properties.",
+          "items": {
+            "$ref": "#/definitions/Property"
+          },
+          "type": "array"
+        },
+        "proposed": {
+          "description": "Whether this is a proposed structure. If omitted, the structure is final.",
+          "type": "boolean"
+        },
+        "since": {
+          "description": "Since when (release number) this structure is available. Is undefined if not known.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "type": "object"
+    },
+    "StructureLiteralType": {
+      "additionalProperties": false,
+      "description": "Represents a literal structure (e.g. `property: { start: uinteger; end: uinteger; }`).",
+      "properties": {
+        "kind": {
+          "const": "literal",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/StructureLiteral"
+        }
+      },
+      "required": [
+        "kind",
+        "value"
+      ],
+      "type": "object"
+    },
+    "TupleType": {
+      "additionalProperties": false,
+      "description": "Represents a `tuple` type (e.g. `[integer, integer]`).",
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/definitions/Type"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "const": "tuple",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kind",
+        "items"
+      ],
+      "type": "object"
+    },
+    "Type": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BaseType"
+        },
+        {
+          "$ref": "#/definitions/ReferenceType"
+        },
+        {
+          "$ref": "#/definitions/ArrayType"
+        },
+        {
+          "$ref": "#/definitions/MapType"
+        },
+        {
+          "$ref": "#/definitions/AndType"
+        },
+        {
+          "$ref": "#/definitions/OrType"
+        },
+        {
+          "$ref": "#/definitions/TupleType"
+        },
+        {
+          "$ref": "#/definitions/StructureLiteralType"
+        },
+        {
+          "$ref": "#/definitions/StringLiteralType"
+        },
+        {
+          "$ref": "#/definitions/IntegerLiteralType"
+        },
+        {
+          "$ref": "#/definitions/BooleanLiteralType"
+        }
+      ]
+    },
+    "TypeAlias": {
+      "additionalProperties": false,
+      "description": "Defines a type alias. (e.g. `type Definition = Location | LocationLink`)",
+      "properties": {
+        "deprecated": {
+          "description": "Whether the type alias is deprecated or not. If deprecated the property contains the deprecation message.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "An optional documentation.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the type alias.",
+          "type": "string"
+        },
+        "proposed": {
+          "description": "Whether this is a proposed type alias. If omitted, the type alias is final.",
+          "type": "boolean"
+        },
+        "since": {
+          "description": "Since when (release number) this structure is available. Is undefined if not known.",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The aliased type."
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TypeKind": {
+      "enum": [
+        "base",
+        "reference",
+        "array",
+        "map",
+        "and",
+        "or",
+        "tuple",
+        "literal",
+        "stringLiteral",
+        "integerLiteral",
+        "booleanLiteral"
+      ],
+      "type": "string"
     }
+  }
 }

--- a/generator/model.py
+++ b/generator/model.py
@@ -105,6 +105,10 @@ class EnumItem:
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
+    deprecated: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+        default=None,
+    )
 
 
 @attrs.define
@@ -137,6 +141,10 @@ class Enum:
     )
     supportsCustomValues: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
+        default=None,
+    )
+    deprecated: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
 
@@ -273,6 +281,10 @@ class Property:
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
+    deprecated: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+        default=None,
+    )
 
 
 @attrs.define
@@ -305,6 +317,10 @@ class LiteralType:
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
+    deprecated: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+        default=None,
+    )
 
 
 @attrs.define
@@ -323,6 +339,10 @@ class TypeAlias:
         default=None,
     )
     since: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+        default=None,
+    )
+    deprecated: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
@@ -349,6 +369,10 @@ class Structure:
         default=None,
     )
     since: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+        default=None,
+    )
+    deprecated: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
@@ -383,6 +407,10 @@ class Notification:
         default=None,
     )
     registrationMethod: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+        default=None,
+    )
+    deprecated: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
@@ -432,6 +460,10 @@ class Request:
         default=None,
     )
     registrationMethod: Optional[str] = attrs.field(
+        validator=attrs.validators.optional(attrs.validators.instance_of(str)),
+        default=None,
+    )
+    deprecated: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )

--- a/lsprotocol/types.py
+++ b/lsprotocol/types.py
@@ -691,8 +691,9 @@ class TokenFormat(str, enum.Enum):
 
 
 Definition = Union["Location", List["Location"]]
-"""The definition of a symbol represented as one or many locations. For most
-programming languages there is only one location at which a symbol is defined.
+"""The definition of a symbol represented as one or many {@link Location
+locations}. For most programming languages there is only one location at which
+a symbol is defined.
 
 Servers should prefer returning `DefinitionLink` over `Definition` if
 supported by the client.
@@ -700,8 +701,8 @@ supported by the client.
 DefinitionLink = Union["LocationLink", "LocationLink"]
 """Information about where a symbol is defined.
 
-Provides additional metadata over normal location definitions, including
-the range of the defining symbol
+Provides additional metadata over normal {@link Location location}
+definitions, including the range of the defining symbol
 """
 LSPArray = List["LSPAny"]
 """LSP arrays.
@@ -719,11 +720,12 @@ optional as well.
 """
 # Since: 3.17.0
 Declaration = Union["Location", List["Location"]]
-"""The declaration of a symbol representation as one or many locations."""
+"""The declaration of a symbol representation as one or many {@link Location
+locations}."""
 DeclarationLink = Union["LocationLink", "LocationLink"]
 """Information about where a symbol is declared.
 
-Provides additional metadata over normal location declarations, including the range of
+Provides additional metadata over normal {@link Location location} declarations, including the range of
 the declaring symbol.
 
 Servers should prefer returning `DeclarationLink` over `Declaration` if supported
@@ -752,6 +754,8 @@ comparison to the last pull request.
 
 @since 3.17.0
 """
+
+
 # Since: 3.17.0
 @attrs.define
 class PrepareRenameResult_Type1:
@@ -768,7 +772,6 @@ class PrepareRenameResult_Type2:
 PrepareRenameResult = Union[
     "Range", "PrepareRenameResult_Type1", "PrepareRenameResult_Type2"
 ]
-ProgressToken = Union[int, str]
 DocumentSelector = List["DocumentFilter"]
 """A document selector is the combination of one or many document filters.
 
@@ -777,6 +780,7 @@ DocumentSelector = List["DocumentFilter"]
 The use of a string as a document filter is deprecated @since 3.16.0.
 """
 # Since: 3.16.0.
+ProgressToken = Union[int, str]
 ChangeAnnotationIdentifier = str
 """An identifier to refer to a change annotation stored with a workspace
 edit."""
@@ -788,6 +792,8 @@ WorkspaceDocumentDiagnosticReport = Union[
 
 @since 3.17.0
 """
+
+
 # Since: 3.17.0
 @attrs.define
 class TextDocumentContentChangeEvent_Type1:
@@ -852,11 +858,19 @@ document.
 @since 3.17.0 - proposed support for NotebookCellTextDocumentFilter.
 """
 # Since: 3.17.0 - proposed support for NotebookCellTextDocumentFilter.
+LSPObject = Dict[str, LSPAny]
+"""LSP object definition.
+
+@since 3.17.0
+"""
+# Since: 3.17.0
 GlobPattern = Union["Pattern", "RelativePattern"]
 """The glob pattern. Either a string pattern or a relative pattern.
 
 @since 3.17.0
 """
+
+
 # Since: 3.17.0
 @attrs.define
 class TextDocumentFilter_Type1:
@@ -867,7 +881,7 @@ class TextDocumentFilter_Type1:
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
-    """A Uri scheme, like `file` or `untitled`."""
+    """A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."""
 
     pattern: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
@@ -879,7 +893,7 @@ class TextDocumentFilter_Type1:
 @attrs.define
 class TextDocumentFilter_Type2:
     scheme: str = attrs.field(validator=attrs.validators.instance_of(str))
-    """A Uri scheme, like `file` or `untitled`."""
+    """A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."""
 
     language: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
@@ -909,15 +923,16 @@ class TextDocumentFilter_Type3:
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
-    """A Uri scheme, like `file` or `untitled`."""
+    """A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."""
 
 
 TextDocumentFilter = Union[
     "TextDocumentFilter_Type1", "TextDocumentFilter_Type2", "TextDocumentFilter_Type3"
 ]
-"""A document filter denotes a document by different properties like the
-language, the scheme of its resource, or a glob-pattern that is applied to the
-path.
+"""A document filter denotes a document by different properties like the {@link
+TextDocument.languageId language}, the {@link Uri.scheme scheme} of its
+resource, or a glob-pattern that is applied to the {@link TextDocument.fileName
+path}.
 
 Glob patterns can have the following syntax:
 - `*` to match one or more characters in a path segment
@@ -932,6 +947,8 @@ Glob patterns can have the following syntax:
 
 @since 3.17.0
 """
+
+
 # Since: 3.17.0
 @attrs.define
 class NotebookDocumentFilter_Type1:
@@ -942,7 +959,7 @@ class NotebookDocumentFilter_Type1:
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
-    """A Uri scheme, like `file` or `untitled`."""
+    """A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."""
 
     pattern: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
@@ -954,7 +971,7 @@ class NotebookDocumentFilter_Type1:
 @attrs.define
 class NotebookDocumentFilter_Type2:
     scheme: str = attrs.field(validator=attrs.validators.instance_of(str))
-    """A Uri scheme, like `file` or `untitled`."""
+    """A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."""
 
     notebook_type: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
@@ -984,7 +1001,7 @@ class NotebookDocumentFilter_Type3:
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
         default=None,
     )
-    """A Uri scheme, like `file` or `untitled`."""
+    """A Uri {@link Uri.scheme scheme}, like `file` or `untitled`."""
 
 
 NotebookDocumentFilter = Union[
@@ -1012,6 +1029,8 @@ the following syntax:
 
 @since 3.17.0
 """
+
+
 # Since: 3.17.0
 @attrs.define
 class TextDocumentPositionParams:
@@ -1227,7 +1246,7 @@ class ConfigurationParams:
 
 @attrs.define
 class DocumentColorParams:
-    """Parameters for a DocumentColorRequest."""
+    """Parameters for a {@link DocumentColorRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -1288,7 +1307,7 @@ class DocumentColorRegistrationOptions:
 
 @attrs.define
 class ColorPresentationParams:
-    """Parameters for a ColorPresentationRequest."""
+    """Parameters for a {@link ColorPresentationRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -1320,23 +1339,24 @@ class ColorPresentation:
     """
 
     text_edit: Optional["TextEdit"] = attrs.field(default=None)
-    """An edit which is applied to a document when selecting this presentation
-    for the color.
+    """An {@link TextEdit edit} which is applied to a document when selecting
+    this presentation for the color.
 
-    When `falsy` the label is used.
+    When `falsy` the {@link ColorPresentation.label label} is used.
     """
 
     additional_text_edits: Optional[List["TextEdit"]] = attrs.field(default=None)
-    """An optional array of additional text edits that are applied when
-    selecting this color presentation.
+    """An optional array of additional {@link TextEdit text edits} that are
+    applied when selecting this color presentation.
 
-    Edits must not overlap with the main edit nor with themselves.
+    Edits must not overlap with the main {@link
+    ColorPresentation.textEdit edit} nor with themselves.
     """
 
 
 @attrs.define
 class FoldingRangeParams:
-    """Parameters for a FoldingRangeRequest."""
+    """Parameters for a {@link FoldingRangeRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -1394,8 +1414,8 @@ class FoldingRange:
     """Describes the kind of the folding range such as `comment' or 'region'.
 
     The kind is used to categorize folding ranges and used by commands
-    like 'Fold all comments'. See FoldingRangeKind for an enumeration of
-    standardized kinds.
+    like 'Fold all comments'. See {@link FoldingRangeKind} for an
+    enumeration of standardized kinds.
     """
 
     collapsed_text: Optional[str] = attrs.field(
@@ -1524,7 +1544,7 @@ class SelectionRange:
     """
 
     range: "Range" = attrs.field()
-    """The range of this selection range."""
+    """The {@link Range range} of this selection range."""
 
     parent: Optional["SelectionRange"] = attrs.field(default=None)
     """The parent selection range containing this range.
@@ -1626,7 +1646,7 @@ class CallHierarchyItem:
     """The range that should be selected and revealed when this symbol is being
     picked, e.g. the name of a function.
 
-    Must be contained by the [`range`](#CallHierarchyItem.range).
+    Must be contained by the {@link CallHierarchyItem.range `range`}.
     """
 
     tags: Optional[List[SymbolTag]] = attrs.field(default=None)
@@ -1726,8 +1746,8 @@ class CallHierarchyIncomingCall:
     from_ranges: List["Range"] = attrs.field()
     """The ranges at which the calls appear.
 
-    This is relative to the caller denoted by
-    [`this.from`](#CallHierarchyIncomingCall.from).
+    This is relative to the caller denoted by {@link
+    CallHierarchyIncomingCall.from `this.from`}.
     """
 
 
@@ -1767,8 +1787,8 @@ class CallHierarchyOutgoingCall:
     """The range at which this item is called.
 
     This is the range relative to the caller, e.g the item
-    passed to [`provideCallHierarchyOutgoingCalls`](#CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls)
-    and not [`this.to`](#CallHierarchyOutgoingCall.to).
+    passed to {@link CallHierarchyItemProvider.provideCallHierarchyOutgoingCalls `provideCallHierarchyOutgoingCalls`}
+    and not {@link CallHierarchyOutgoingCall.to `this.to`}.
     """
 
 
@@ -2324,7 +2344,7 @@ class TypeHierarchyItem:
     """The range that should be selected and revealed when this symbol is being
     picked, e.g. the name of a function. Must be contained by the.
 
-    [`range`](#TypeHierarchyItem.range).
+    {@link TypeHierarchyItem.range `range`}.
     """
 
     tags: Optional[List[SymbolTag]] = attrs.field(default=None)
@@ -3006,7 +3026,7 @@ class _InitializeParams:
     initialization_options: Optional[LSPAny] = attrs.field(default=None)
     """User provided initialization options."""
 
-    trace: Optional[Union[str, str, str, str]] = attrs.field(default=None)
+    trace: Optional[TraceValues] = attrs.field(default=None)
     """The initial trace setting.
 
     If omitted trace is disabled ('off').
@@ -3081,7 +3101,7 @@ class InitializeParams:
     initialization_options: Optional[LSPAny] = attrs.field(default=None)
     """User provided initialization options."""
 
-    trace: Optional[Union[str, str, str, str]] = attrs.field(default=None)
+    trace: Optional[TraceValues] = attrs.field(default=None)
     """The initial trace setting.
 
     If omitted trace is disabled ('off').
@@ -3481,7 +3501,7 @@ class CompletionItem:
     )
     """A string that should be used when comparing this item with other items.
 
-    When `falsy` the label is used.
+    When `falsy` the {@link CompletionItem.label label} is used.
     """
 
     filter_text: Optional[str] = attrs.field(
@@ -3490,7 +3510,7 @@ class CompletionItem:
     )
     """A string that should be used when filtering a set of completion items.
 
-    When `falsy` the label is used.
+    When `falsy` the {@link CompletionItem.label label} is used.
     """
 
     insert_text: Optional[str] = attrs.field(
@@ -3498,7 +3518,7 @@ class CompletionItem:
         default=None,
     )
     """A string that should be inserted into a document when selecting this
-    completion. When `falsy` the label is used.
+    completion. When `falsy` the {@link CompletionItem.label label} is used.
 
     The `insertText` is subject to interpretation by the client side.
     Some tools might not take the string literally. For example VS Code
@@ -3530,8 +3550,10 @@ class CompletionItem:
     text_edit: Optional[Union[TextEdit, "InsertReplaceEdit"]] = attrs.field(
         default=None
     )
-    """An edit which is applied to a document when selecting this completion.
-    When an edit is provided the value of insertText is ignored.
+    """An {@link TextEdit edit} which is applied to a document when selecting
+    this completion. When an edit is provided the value of.
+
+    {@link CompletionItem.insertText insertText} is ignored.
 
     Most editors support two different operations when accepting a completion
     item. One is to insert a completion text and the other is to replace an
@@ -3570,9 +3592,10 @@ class CompletionItem:
     # Since: 3.17.0
 
     additional_text_edits: Optional[List[TextEdit]] = attrs.field(default=None)
-    """An optional array of additional text edits that are applied when
-    selecting this completion. Edits must not overlap (including the same
-    insert position) with the main edit nor with themselves.
+    """An optional array of additional {@link TextEdit text edits} that are
+    applied when selecting this completion. Edits must not overlap (including
+    the same insert position) with the main {@link CompletionItem.textEdit
+    edit} nor with themselves.
 
     Additional text edits should be used to change text unrelated to the
     current cursor position (for example adding an import statement at
@@ -3589,16 +3612,19 @@ class CompletionItem:
     """
 
     command: Optional["Command"] = attrs.field(default=None)
-    """An optional command that is executed *after* inserting this completion.
+    """An optional {@link Command command} that is executed *after* inserting
+    this completion. *Note* that additional modifications to the current
+    document should be described with the.
 
-    *Note* that
-    additional modifications to the current document should be described with the
-    additionalTextEdits-property.
+    {@link CompletionItem.additionalTextEdits
+    additionalTextEdits}-property.
     """
 
     data: Optional[LSPAny] = attrs.field(default=None)
-    """A data entry field that is preserved on a completion item between a
-    CompletionRequest and a CompletionResolveRequest."""
+    """A data entry field that is preserved on a completion item between a.
+
+    {@link CompletionRequest} and a {@link CompletionResolveRequest}.
+    """
 
 
 @attrs.define
@@ -3650,8 +3676,8 @@ class CompletionListItemDefaultsType:
 
 @attrs.define
 class CompletionList:
-    """Represents a collection of completion items to be presented in the
-    editor."""
+    """Represents a collection of {@link CompletionItem completion items} to be
+    presented in the editor."""
 
     is_incomplete: bool = attrs.field(validator=attrs.validators.instance_of(bool))
     """This list it not complete. Further typing results in recomputing this
@@ -3769,7 +3795,7 @@ class CompletionRegistrationOptionsCompletionItemType:
 
 @attrs.define
 class CompletionRegistrationOptions:
-    """Registration options for a CompletionRequest."""
+    """Registration options for a {@link CompletionRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -3831,7 +3857,7 @@ class CompletionRegistrationOptions:
 
 @attrs.define
 class HoverParams:
-    """Parameters for a HoverRequest."""
+    """Parameters for a {@link HoverRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -3867,7 +3893,7 @@ class HoverOptions:
 
 @attrs.define
 class HoverRegistrationOptions:
-    """Registration options for a HoverRequest."""
+    """Registration options for a {@link HoverRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -3886,7 +3912,7 @@ class HoverRegistrationOptions:
 
 @attrs.define
 class SignatureHelpParams:
-    """Parameters for a SignatureHelpRequest."""
+    """Parameters for a {@link SignatureHelpRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -3948,7 +3974,7 @@ class SignatureHelp:
 
 @attrs.define
 class SignatureHelpOptions:
-    """Server Capabilities for a SignatureHelpRequest."""
+    """Server Capabilities for a {@link SignatureHelpRequest}."""
 
     trigger_characters: Optional[List[str]] = attrs.field(default=None)
     """List of characters that trigger signature help automatically."""
@@ -3971,7 +3997,7 @@ class SignatureHelpOptions:
 
 @attrs.define
 class SignatureHelpRegistrationOptions:
-    """Registration options for a SignatureHelpRequest."""
+    """Registration options for a {@link SignatureHelpRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4003,7 +4029,7 @@ class SignatureHelpRegistrationOptions:
 
 @attrs.define
 class DefinitionParams:
-    """Parameters for a DefinitionRequest."""
+    """Parameters for a {@link DefinitionRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -4021,7 +4047,7 @@ class DefinitionParams:
 
 @attrs.define
 class DefinitionOptions:
-    """Server Capabilities for a DefinitionRequest."""
+    """Server Capabilities for a {@link DefinitionRequest}."""
 
     work_done_progress: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4031,7 +4057,7 @@ class DefinitionOptions:
 
 @attrs.define
 class DefinitionRegistrationOptions:
-    """Registration options for a DefinitionRequest."""
+    """Registration options for a {@link DefinitionRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4050,7 +4076,7 @@ class DefinitionRegistrationOptions:
 
 @attrs.define
 class ReferenceParams:
-    """Parameters for a ReferencesRequest."""
+    """Parameters for a {@link ReferencesRequest}."""
 
     context: "ReferenceContext" = attrs.field()
 
@@ -4080,7 +4106,7 @@ class ReferenceOptions:
 
 @attrs.define
 class ReferenceRegistrationOptions:
-    """Registration options for a ReferencesRequest."""
+    """Registration options for a {@link ReferencesRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4099,7 +4125,7 @@ class ReferenceRegistrationOptions:
 
 @attrs.define
 class DocumentHighlightParams:
-    """Parameters for a DocumentHighlightRequest."""
+    """Parameters for a {@link DocumentHighlightRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -4128,12 +4154,13 @@ class DocumentHighlight:
     """The range this highlight applies to."""
 
     kind: Optional[DocumentHighlightKind] = attrs.field(default=None)
-    """The highlight kind, default is text."""
+    """The highlight kind, default is {@link DocumentHighlightKind.Text
+    text}."""
 
 
 @attrs.define
 class DocumentHighlightOptions:
-    """Provider options for a DocumentHighlightRequest."""
+    """Provider options for a {@link DocumentHighlightRequest}."""
 
     work_done_progress: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4143,7 +4170,7 @@ class DocumentHighlightOptions:
 
 @attrs.define
 class DocumentHighlightRegistrationOptions:
-    """Registration options for a DocumentHighlightRequest."""
+    """Registration options for a {@link DocumentHighlightRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4162,7 +4189,7 @@ class DocumentHighlightRegistrationOptions:
 
 @attrs.define
 class DocumentSymbolParams:
-    """Parameters for a DocumentSymbolRequest."""
+    """Parameters for a {@link DocumentSymbolRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The text document."""
@@ -4319,7 +4346,7 @@ class DocumentSymbol:
 
 @attrs.define
 class DocumentSymbolOptions:
-    """Provider options for a DocumentSymbolRequest."""
+    """Provider options for a {@link DocumentSymbolRequest}."""
 
     label: Optional[str] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(str)),
@@ -4340,7 +4367,7 @@ class DocumentSymbolOptions:
 
 @attrs.define
 class DocumentSymbolRegistrationOptions:
-    """Registration options for a DocumentSymbolRequest."""
+    """Registration options for a {@link DocumentSymbolRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4370,7 +4397,7 @@ class DocumentSymbolRegistrationOptions:
 
 @attrs.define
 class CodeActionParams:
-    """The parameters of a CodeActionRequest."""
+    """The parameters of a {@link CodeActionRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The document in which the command was invoked."""
@@ -4493,7 +4520,7 @@ class CodeAction:
 
 @attrs.define
 class CodeActionOptions:
-    """Provider options for a CodeActionRequest."""
+    """Provider options for a {@link CodeActionRequest}."""
 
     code_action_kinds: Optional[List[Union[CodeActionKind, str]]] = attrs.field(
         default=None
@@ -4523,7 +4550,7 @@ class CodeActionOptions:
 
 @attrs.define
 class CodeActionRegistrationOptions:
-    """Registration options for a CodeActionRequest."""
+    """Registration options for a {@link CodeActionRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4562,7 +4589,7 @@ class CodeActionRegistrationOptions:
 
 @attrs.define
 class WorkspaceSymbolParams:
-    """The parameters of a WorkspaceSymbolRequest."""
+    """The parameters of a {@link WorkspaceSymbolRequest}."""
 
     query: str = attrs.field(validator=attrs.validators.instance_of(str))
     """A query string to filter symbols by.
@@ -4633,7 +4660,7 @@ class WorkspaceSymbol:
 
 @attrs.define
 class WorkspaceSymbolOptions:
-    """Server capabilities for a WorkspaceSymbolRequest."""
+    """Server capabilities for a {@link WorkspaceSymbolRequest}."""
 
     resolve_provider: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4654,7 +4681,7 @@ class WorkspaceSymbolOptions:
 
 @attrs.define
 class WorkspaceSymbolRegistrationOptions:
-    """Registration options for a WorkspaceSymbolRequest."""
+    """Registration options for a {@link WorkspaceSymbolRequest}."""
 
     resolve_provider: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4675,7 +4702,7 @@ class WorkspaceSymbolRegistrationOptions:
 
 @attrs.define
 class CodeLensParams:
-    """The parameters of a CodeLensRequest."""
+    """The parameters of a {@link CodeLensRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The document to request code lens for."""
@@ -4690,8 +4717,9 @@ class CodeLensParams:
 
 @attrs.define
 class CodeLens:
-    """A code lens represents a command that should be shown along with source
-    text, like the number of references, a way to run tests, etc.
+    """A code lens represents a {@link Command command} that should be shown
+    along with source text, like the number of references, a way to run tests,
+    etc.
 
     A code lens is _unresolved_ when no command is associated to it. For
     performance reasons the creation of a code lens and resolving should
@@ -4708,13 +4736,16 @@ class CodeLens:
     """The command this code lens represents."""
 
     data: Optional[LSPAny] = attrs.field(default=None)
-    """A data entry field that is preserved on a code lens item between a
-    CodeLensRequest and a [CodeLensResolveRequest] (#CodeLensResolveRequest)"""
+    """A data entry field that is preserved on a code lens item between a.
+
+    {@link CodeLensRequest} and a [CodeLensResolveRequest]
+    (#CodeLensResolveRequest)
+    """
 
 
 @attrs.define
 class CodeLensOptions:
-    """Code Lens provider options of a CodeLensRequest."""
+    """Code Lens provider options of a {@link CodeLensRequest}."""
 
     resolve_provider: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4730,7 +4761,7 @@ class CodeLensOptions:
 
 @attrs.define
 class CodeLensRegistrationOptions:
-    """Registration options for a CodeLensRequest."""
+    """Registration options for a {@link CodeLensRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4755,7 +4786,7 @@ class CodeLensRegistrationOptions:
 
 @attrs.define
 class DocumentLinkParams:
-    """The parameters of a DocumentLinkRequest."""
+    """The parameters of a {@link DocumentLinkRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The document to provide document links for."""
@@ -4806,7 +4837,7 @@ class DocumentLink:
 
 @attrs.define
 class DocumentLinkOptions:
-    """Provider options for a DocumentLinkRequest."""
+    """Provider options for a {@link DocumentLinkRequest}."""
 
     resolve_provider: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4822,7 +4853,7 @@ class DocumentLinkOptions:
 
 @attrs.define
 class DocumentLinkRegistrationOptions:
-    """Registration options for a DocumentLinkRequest."""
+    """Registration options for a {@link DocumentLinkRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4847,7 +4878,7 @@ class DocumentLinkRegistrationOptions:
 
 @attrs.define
 class DocumentFormattingParams:
-    """The parameters of a DocumentFormattingRequest."""
+    """The parameters of a {@link DocumentFormattingRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The document to format."""
@@ -4861,7 +4892,7 @@ class DocumentFormattingParams:
 
 @attrs.define
 class DocumentFormattingOptions:
-    """Provider options for a DocumentFormattingRequest."""
+    """Provider options for a {@link DocumentFormattingRequest}."""
 
     work_done_progress: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4871,7 +4902,7 @@ class DocumentFormattingOptions:
 
 @attrs.define
 class DocumentFormattingRegistrationOptions:
-    """Registration options for a DocumentFormattingRequest."""
+    """Registration options for a {@link DocumentFormattingRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4890,7 +4921,7 @@ class DocumentFormattingRegistrationOptions:
 
 @attrs.define
 class DocumentRangeFormattingParams:
-    """The parameters of a DocumentRangeFormattingRequest."""
+    """The parameters of a {@link DocumentRangeFormattingRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The document to format."""
@@ -4907,7 +4938,7 @@ class DocumentRangeFormattingParams:
 
 @attrs.define
 class DocumentRangeFormattingOptions:
-    """Provider options for a DocumentRangeFormattingRequest."""
+    """Provider options for a {@link DocumentRangeFormattingRequest}."""
 
     work_done_progress: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -4917,7 +4948,7 @@ class DocumentRangeFormattingOptions:
 
 @attrs.define
 class DocumentRangeFormattingRegistrationOptions:
-    """Registration options for a DocumentRangeFormattingRequest."""
+    """Registration options for a {@link DocumentRangeFormattingRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -4936,7 +4967,7 @@ class DocumentRangeFormattingRegistrationOptions:
 
 @attrs.define
 class DocumentOnTypeFormattingParams:
-    """The parameters of a DocumentOnTypeFormattingRequest."""
+    """The parameters of a {@link DocumentOnTypeFormattingRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The document to format."""
@@ -4963,7 +4994,7 @@ class DocumentOnTypeFormattingParams:
 
 @attrs.define
 class DocumentOnTypeFormattingOptions:
-    """Provider options for a DocumentOnTypeFormattingRequest."""
+    """Provider options for a {@link DocumentOnTypeFormattingRequest}."""
 
     first_trigger_character: str = attrs.field(
         validator=attrs.validators.instance_of(str)
@@ -4976,7 +5007,7 @@ class DocumentOnTypeFormattingOptions:
 
 @attrs.define
 class DocumentOnTypeFormattingRegistrationOptions:
-    """Registration options for a DocumentOnTypeFormattingRequest."""
+    """Registration options for a {@link DocumentOnTypeFormattingRequest}."""
 
     first_trigger_character: str = attrs.field(
         validator=attrs.validators.instance_of(str)
@@ -4998,7 +5029,7 @@ class DocumentOnTypeFormattingRegistrationOptions:
 
 @attrs.define
 class RenameParams:
-    """The parameters of a RenameRequest."""
+    """The parameters of a {@link RenameRequest}."""
 
     text_document: "TextDocumentIdentifier" = attrs.field()
     """The document to rename."""
@@ -5009,8 +5040,8 @@ class RenameParams:
     new_name: str = attrs.field(validator=attrs.validators.instance_of(str))
     """The new name of the symbol.
 
-    If the given name is not valid the request must return a
-    ResponseError with an appropriate message set.
+    If the given name is not valid the request must return a {@link
+    ResponseError} with an appropriate message set.
     """
 
     work_done_token: Optional[ProgressToken] = attrs.field(default=None)
@@ -5019,7 +5050,7 @@ class RenameParams:
 
 @attrs.define
 class RenameOptions:
-    """Provider options for a RenameRequest."""
+    """Provider options for a {@link RenameRequest}."""
 
     prepare_provider: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -5039,7 +5070,7 @@ class RenameOptions:
 
 @attrs.define
 class RenameRegistrationOptions:
-    """Registration options for a RenameRequest."""
+    """Registration options for a {@link RenameRequest}."""
 
     document_selector: Optional[Union[DocumentSelector, None]] = attrs.field(
         default=None
@@ -5080,7 +5111,7 @@ class PrepareRenameParams:
 
 @attrs.define
 class ExecuteCommandParams:
-    """The parameters of a ExecuteCommandRequest."""
+    """The parameters of a {@link ExecuteCommandRequest}."""
 
     command: str = attrs.field(validator=attrs.validators.instance_of(str))
     """The identifier of the actual command handler."""
@@ -5094,7 +5125,7 @@ class ExecuteCommandParams:
 
 @attrs.define
 class ExecuteCommandOptions:
-    """The server capabilities of a ExecuteCommandRequest."""
+    """The server capabilities of a {@link ExecuteCommandRequest}."""
 
     commands: List[str] = attrs.field()
     """The commands to be executed on the server."""
@@ -5107,7 +5138,7 @@ class ExecuteCommandOptions:
 
 @attrs.define
 class ExecuteCommandRegistrationOptions:
-    """Registration options for a ExecuteCommandRequest."""
+    """Registration options for a {@link ExecuteCommandRequest}."""
 
     commands: List[str] = attrs.field()
     """The commands to be executed on the server."""
@@ -5300,8 +5331,8 @@ class ProgressParams:
 class LocationLink:
     """Represents the connection of two locations.
 
-    Provides additional metadata over normal locations, including an
-    origin range.
+    Provides additional metadata over normal {@link Location locations},
+    including an origin range.
     """
 
     target_uri: str = attrs.field(validator=attrs.validators.instance_of(str))
@@ -6033,7 +6064,7 @@ class NotebookDocument:
     cells: List["NotebookCell"] = attrs.field()
     """The cells of a notebook."""
 
-    metadata: Optional["LSPObject"] = attrs.field(default=None)
+    metadata: Optional[LSPObject] = attrs.field(default=None)
     """Additional metadata stored with the notebook document.
 
     Note: should always be an object literal (e.g. LSPObject)
@@ -6119,7 +6150,7 @@ class NotebookDocumentChangeEvent:
 
     # Since: 3.17.0
 
-    metadata: Optional["LSPObject"] = attrs.field(default=None)
+    metadata: Optional[LSPObject] = attrs.field(default=None)
     """The changed meta data if any.
 
     Note: should always be an object literal (e.g. LSPObject)
@@ -6683,8 +6714,10 @@ class ReferenceContext:
 
 @attrs.define
 class CodeActionContext:
-    """Contains additional diagnostic information about the context in which a
-    code action is run."""
+    """Contains additional diagnostic information about the context in which a.
+
+    {@link CodeActionProvider.provideCodeActions code action} is run.
+    """
 
     diagnostics: List[Diagnostic] = attrs.field()
     """An array of diagnostics known on the client side overlapping the range
@@ -6963,14 +6996,6 @@ class WorkspaceUnchangedDocumentDiagnosticReport:
 
     A server can only return `unchanged` if result ids are provided.
     """
-
-
-LSPObject = object
-"""LSP object definition.
-
-@since 3.17.0
-"""
-# Since: 3.17.0
 
 
 @attrs.define
@@ -7984,7 +8009,7 @@ class WorkspaceSymbolClientCapabilitiesResolveSupportType:
 
 @attrs.define
 class WorkspaceSymbolClientCapabilities:
-    """Client capabilities for a WorkspaceSymbolRequest."""
+    """Client capabilities for a {@link WorkspaceSymbolRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8022,7 +8047,7 @@ class WorkspaceSymbolClientCapabilities:
 
 @attrs.define
 class ExecuteCommandClientCapabilities:
-    """The client capabilities of a ExecuteCommandRequest."""
+    """The client capabilities of a {@link ExecuteCommandRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8470,7 +8495,7 @@ class SignatureHelpClientCapabilitiesSignatureInformationType:
 
 @attrs.define
 class SignatureHelpClientCapabilities:
-    """Client Capabilities for a SignatureHelpRequest."""
+    """Client Capabilities for a {@link SignatureHelpRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8525,7 +8550,7 @@ class DeclarationClientCapabilities:
 
 @attrs.define
 class DefinitionClientCapabilities:
-    """Client Capabilities for a DefinitionRequest."""
+    """Client Capabilities for a {@link DefinitionRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8599,7 +8624,7 @@ class ImplementationClientCapabilities:
 
 @attrs.define
 class ReferenceClientCapabilities:
-    """Client Capabilities for a ReferencesRequest."""
+    """Client Capabilities for a {@link ReferencesRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8610,7 +8635,7 @@ class ReferenceClientCapabilities:
 
 @attrs.define
 class DocumentHighlightClientCapabilities:
-    """Client Capabilities for a DocumentHighlightRequest."""
+    """Client Capabilities for a {@link DocumentHighlightRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8640,7 +8665,7 @@ class DocumentSymbolClientCapabilitiesTagSupportType:
 
 @attrs.define
 class DocumentSymbolClientCapabilities:
-    """Client Capabilities for a DocumentSymbolRequest."""
+    """Client Capabilities for a {@link DocumentSymbolRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8710,7 +8735,7 @@ class CodeActionClientCapabilitiesResolveSupportType:
 
 @attrs.define
 class CodeActionClientCapabilities:
-    """The Client Capabilities of a CodeActionRequest."""
+    """The Client Capabilities of a {@link CodeActionRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8786,7 +8811,7 @@ class CodeActionClientCapabilities:
 
 @attrs.define
 class CodeLensClientCapabilities:
-    """The client capabilities  of a CodeLensRequest."""
+    """The client capabilities  of a {@link CodeLensRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8797,7 +8822,7 @@ class CodeLensClientCapabilities:
 
 @attrs.define
 class DocumentLinkClientCapabilities:
-    """The client capabilities of a DocumentLinkRequest."""
+    """The client capabilities of a {@link DocumentLinkRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8832,7 +8857,7 @@ class DocumentColorClientCapabilities:
 
 @attrs.define
 class DocumentFormattingClientCapabilities:
-    """Client capabilities of a DocumentFormattingRequest."""
+    """Client capabilities of a {@link DocumentFormattingRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8843,7 +8868,7 @@ class DocumentFormattingClientCapabilities:
 
 @attrs.define
 class DocumentRangeFormattingClientCapabilities:
-    """Client capabilities of a DocumentRangeFormattingRequest."""
+    """Client capabilities of a {@link DocumentRangeFormattingRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -8854,7 +8879,7 @@ class DocumentRangeFormattingClientCapabilities:
 
 @attrs.define
 class DocumentOnTypeFormattingClientCapabilities:
-    """Client capabilities of a DocumentOnTypeFormattingRequest."""
+    """Client capabilities of a {@link DocumentOnTypeFormattingRequest}."""
 
     dynamic_registration: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -9420,15 +9445,6 @@ class MarkdownClientCapabilities:
 
 
 @attrs.define
-class WorkspaceConfigurationParams:
-    items: List[ConfigurationItem] = attrs.field()
-
-    partial_result_token: Optional[ProgressToken] = attrs.field(default=None)
-    """An optional token that a server can use to report partial results (e.g.
-    streaming) to the client."""
-
-
-@attrs.define
 class TextDocumentColorPresentationOptions:
     work_done_progress: Optional[bool] = attrs.field(
         validator=attrs.validators.optional(attrs.validators.instance_of(bool)),
@@ -9474,8 +9490,8 @@ class TextDocumentImplementationRequest:
     text document position.
 
     The request's parameter is of type [TextDocumentPositionParams]
-    (#TextDocumentPositionParams) the response is of type Definition or
-    a Thenable that resolves to such.
+    (#TextDocumentPositionParams) the response is of type {@link
+    Definition} or a Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -9500,8 +9516,8 @@ class TextDocumentTypeDefinitionRequest:
     given text document position.
 
     The request's parameter is of type [TextDocumentPositionParams]
-    (#TextDocumentPositionParams) the response is of type Definition or
-    a Thenable that resolves to such.
+    (#TextDocumentPositionParams) the response is of type {@link
+    Definition} or a Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -9556,7 +9572,7 @@ class WorkspaceConfigurationRequest:
 
     id: Union[int, str] = attrs.field()
     """The request id."""
-    params: WorkspaceConfigurationParams = attrs.field()
+    params: ConfigurationParams = attrs.field()
     method: str = "workspace/configuration"
     """The method to be invoked."""
     jsonrpc: str = attrs.field(default="2.0")
@@ -9574,8 +9590,9 @@ class WorkspaceConfigurationResponse:
 class TextDocumentDocumentColorRequest:
     """A request to list all color symbols found in a given text document.
 
-    The request's parameter is of type DocumentColorParams the response
-    is of type ColorInformation[] or a Thenable that resolves to such.
+    The request's parameter is of type {@link DocumentColorParams} the
+    response is of type {@link ColorInformation ColorInformation[]} or a
+    Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -9598,9 +9615,9 @@ class TextDocumentDocumentColorResponse:
 class TextDocumentColorPresentationRequest:
     """A request to list all presentation for a color.
 
-    The request's parameter is of type ColorPresentationParams the
-    response is of type ColorInformation[] or a Thenable that resolves
-    to such.
+    The request's parameter is of type {@link ColorPresentationParams}
+    the response is of type {@link ColorInformation ColorInformation[]}
+    or a Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -9623,8 +9640,9 @@ class TextDocumentColorPresentationResponse:
 class TextDocumentFoldingRangeRequest:
     """A request to provide folding ranges in a document.
 
-    The request's parameter is of type FoldingRangeParams, the response
-    is of type FoldingRangeList or a Thenable that resolves to such.
+    The request's parameter is of type {@link FoldingRangeParams}, the
+    response is of type {@link FoldingRangeList} or a Thenable that
+    resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -9649,9 +9667,9 @@ class TextDocumentDeclarationRequest:
     given text document position.
 
     The request's parameter is of type [TextDocumentPositionParams]
-    (#TextDocumentPositionParams) the response is of type Declaration or
-    a typed array of DeclarationLink or a Thenable that resolves to
-    such.
+    (#TextDocumentPositionParams) the response is of type {@link
+    Declaration} or a typed array of {@link DeclarationLink} or a
+    Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -9674,8 +9692,8 @@ class TextDocumentDeclarationResponse:
 class TextDocumentSelectionRangeRequest:
     """A request to provide selection ranges in a document.
 
-    The request's parameter is of type SelectionRangeParams, the
-    response is of type [SelectionRange[]](#SelectionRange[]) or a
+    The request's parameter is of type {@link SelectionRangeParams}, the
+    response is of type {@link SelectionRange SelectionRange[]} or a
     Thenable that resolves to such.
     """
 
@@ -9995,8 +10013,8 @@ class TextDocumentMonikerRequest:
     """A request to get the moniker of a symbol at a given text document
     position.
 
-    The request parameter is of type TextDocumentPositionParams. The
-    response is of type [Moniker[]](#Moniker[]) or `null`.
+    The request parameter is of type {@link TextDocumentPositionParams}.
+    The response is of type {@link Moniker Moniker[]} or `null`.
     """
 
     id: Union[int, str] = attrs.field()
@@ -10089,9 +10107,9 @@ class TypeHierarchySubtypesResponse:
 @attrs.define
 class TextDocumentInlineValueRequest:
     """A request to provide inline values in a document. The request's
-    parameter is of type InlineValueParams, the response is of type.
+    parameter is of type {@link InlineValueParams}, the response is of type.
 
-    [InlineValue[]](#InlineValue[]) or a Thenable that resolves to such.
+    {@link InlineValue InlineValue[]} or a Thenable that resolves to such.
 
     @since 3.17.0
     """
@@ -10135,9 +10153,9 @@ class WorkspaceInlineValueRefreshResponse:
 @attrs.define
 class TextDocumentInlayHintRequest:
     """A request to provide inlay hints in a document. The request's parameter
-    is of type InlayHintsParams, the response is of type.
+    is of type {@link InlayHintsParams}, the response is of type.
 
-    [InlayHint[]](#InlayHint[]) or a Thenable that resolves to such.
+    {@link InlayHint InlayHint[]} or a Thenable that resolves to such.
 
     @since 3.17.0
     """
@@ -10161,8 +10179,9 @@ class TextDocumentInlayHintResponse:
 @attrs.define
 class InlayHintResolveRequest:
     """A request to resolve additional properties for an inlay hint. The
-    request's parameter is of type InlayHint, the response is of type InlayHint
-    or a Thenable that resolves to such.
+    request's parameter is of type {@link InlayHint}, the response is of type.
+
+    {@link InlayHint} or a Thenable that resolves to such.
 
     @since 3.17.0
     """
@@ -10320,8 +10339,9 @@ class InitializeRequest:
     """The initialize request is sent from the client to the server.
 
     It is sent once as the request after starting up the server. The
-    requests parameter is of type InitializeParams the response if of
-    type InitializeResult of a Thenable that resolves to such.
+    requests parameter is of type {@link InitializeParams} the response
+    if of type {@link InitializeResult} of a Thenable that resolves to
+    such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -10417,12 +10437,13 @@ class TextDocumentWillSaveWaitUntilResponse:
 @attrs.define
 class TextDocumentCompletionRequest:
     """Request to request completion at a given text document position. The
-    request's parameter is of type TextDocumentPosition the response is of type
-    CompletionItem[] or CompletionList or a Thenable that resolves to such.
+    request's parameter is of type {@link TextDocumentPosition} the response is
+    of type {@link CompletionItem CompletionItem[]} or {@link CompletionList}
+    or a Thenable that resolves to such.
 
-    The request can delay the computation of the
-    [`detail`](#CompletionItem.detail) and
-    [`documentation`](#CompletionItem.documentation) properties to the
+    The request can delay the computation of the {@link
+    CompletionItem.detail `detail`} and {@link
+    CompletionItem.documentation `documentation`} properties to the
     `completionItem/resolve` request. However, properties that are
     needed for the initial sorting and filtering, like `sortText`,
     `filterText`, `insertText`, and `textEdit`, must not be changed
@@ -10450,8 +10471,8 @@ class TextDocumentCompletionResponse:
 @attrs.define
 class CompletionItemResolveRequest:
     """Request to resolve additional information for a given completion
-    item.The request's parameter is of type CompletionItem the response is of
-    type CompletionItem or a Thenable that resolves to such."""
+    item.The request's parameter is of type {@link CompletionItem} the response
+    is of type {@link CompletionItem} or a Thenable that resolves to such."""
 
     id: Union[int, str] = attrs.field()
     """The request id."""
@@ -10473,8 +10494,9 @@ class CompletionItemResolveResponse:
 class TextDocumentHoverRequest:
     """Request to request hover information at a given text document position.
 
-    The request's parameter is of type TextDocumentPosition the response
-    is of type Hover or a Thenable that resolves to such.
+    The request's parameter is of type {@link TextDocumentPosition} the
+    response is of type {@link Hover} or a Thenable that resolves to
+    such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -10517,8 +10539,9 @@ class TextDocumentDefinitionRequest:
     document position.
 
     The request's parameter is of type [TextDocumentPosition]
-    (#TextDocumentPosition) the response is of either type Definition or
-    a typed array of DefinitionLink or a Thenable that resolves to such.
+    (#TextDocumentPosition) the response is of either type {@link
+    Definition} or a typed array of {@link DefinitionLink} or a Thenable
+    that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -10540,10 +10563,10 @@ class TextDocumentDefinitionResponse:
 @attrs.define
 class TextDocumentReferencesRequest:
     """A request to resolve project-wide references for the symbol denoted by
-    the given text document position.
+    the given text document position. The request's parameter is of type {@link
+    ReferenceParams} the response is of type.
 
-    The request's parameter is of type ReferenceParams the response is
-    of type Location[] or a Thenable that resolves to such.
+    {@link Location Location[]} or a Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -10564,7 +10587,7 @@ class TextDocumentReferencesResponse:
 
 @attrs.define
 class TextDocumentDocumentHighlightRequest:
-    """Request to resolve a DocumentHighlight for a given text document
+    """Request to resolve a {@link DocumentHighlight} for a given text document
     position.
 
     The request's parameter is of type [TextDocumentPosition]
@@ -10593,9 +10616,9 @@ class TextDocumentDocumentHighlightResponse:
 class TextDocumentDocumentSymbolRequest:
     """A request to list all symbols found in a given text document.
 
-    The request's parameter is of type TextDocumentIdentifier the
-    response is of type SymbolInformation[] or a Thenable that resolves
-    to such.
+    The request's parameter is of type {@link TextDocumentIdentifier}
+    the response is of type {@link SymbolInformation
+    SymbolInformation[]} or a Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -10639,8 +10662,10 @@ class TextDocumentCodeActionResponse:
 @attrs.define
 class CodeActionResolveRequest:
     """Request to resolve additional information for a given code action.The
-    request's parameter is of type CodeAction the response is of type
-    CodeAction or a Thenable that resolves to such."""
+    request's parameter is of type {@link CodeAction} the response is of type.
+
+    {@link CodeAction} or a Thenable that resolves to such.
+    """
 
     id: Union[int, str] = attrs.field()
     """The request id."""
@@ -10661,8 +10686,8 @@ class CodeActionResolveResponse:
 @attrs.define
 class WorkspaceSymbolRequest:
     """A request to list project-wide symbols matching the query string given
-    by the WorkspaceSymbolParams. The response is of type SymbolInformation[]
-    or a Thenable that resolves to such.
+    by the {@link WorkspaceSymbolParams}. The response is of type {@link
+    SymbolInformation SymbolInformation[]} or a Thenable that resolves to such.
 
     @since 3.17.0 - support for WorkspaceSymbol in the returned data. Clients
      need to advertise support for WorkspaceSymbols via the client capability
@@ -10797,8 +10822,8 @@ class TextDocumentDocumentLinkResponse:
 class DocumentLinkResolveRequest:
     """Request to resolve additional information for a given document link.
 
-    The request's parameter is of type DocumentLink the response is of
-    type DocumentLink or a Thenable that resolves to such.
+    The request's parameter is of type {@link DocumentLink} the response
+    is of type {@link DocumentLink} or a Thenable that resolves to such.
     """
 
     id: Union[int, str] = attrs.field()
@@ -11751,7 +11776,7 @@ METHOD_TO_TYPES = {
     WORKSPACE_CONFIGURATION: (
         WorkspaceConfigurationRequest,
         WorkspaceConfigurationResponse,
-        WorkspaceConfigurationParams,
+        ConfigurationParams,
         None,
     ),
     WORKSPACE_DIAGNOSTIC: (
@@ -13238,7 +13263,6 @@ ALL_TYPES_MAP: Dict[str, Union[type, object]] = {
     "WorkspaceClientCapabilities": WorkspaceClientCapabilities,
     "WorkspaceCodeLensRefreshRequest": WorkspaceCodeLensRefreshRequest,
     "WorkspaceCodeLensRefreshResponse": WorkspaceCodeLensRefreshResponse,
-    "WorkspaceConfigurationParams": WorkspaceConfigurationParams,
     "WorkspaceConfigurationRequest": WorkspaceConfigurationRequest,
     "WorkspaceConfigurationResponse": WorkspaceConfigurationResponse,
     "WorkspaceDiagnosticParams": WorkspaceDiagnosticParams,
@@ -13351,11 +13375,11 @@ _MESSAGE_DIRECTION: Dict[str, str] = {
     WORKSPACE_CODE_LENS_REFRESH: "serverToClient",
     WORKSPACE_CONFIGURATION: "serverToClient",
     WORKSPACE_DIAGNOSTIC: "clientToServer",
-    WORKSPACE_DIAGNOSTIC_REFRESH: "clientToServer",
+    WORKSPACE_DIAGNOSTIC_REFRESH: "serverToClient",
     WORKSPACE_EXECUTE_COMMAND: "clientToServer",
-    WORKSPACE_INLAY_HINT_REFRESH: "clientToServer",
-    WORKSPACE_INLINE_VALUE_REFRESH: "clientToServer",
-    WORKSPACE_SEMANTIC_TOKENS_REFRESH: "clientToServer",
+    WORKSPACE_INLAY_HINT_REFRESH: "serverToClient",
+    WORKSPACE_INLINE_VALUE_REFRESH: "serverToClient",
+    WORKSPACE_SEMANTIC_TOKENS_REFRESH: "serverToClient",
     WORKSPACE_SYMBOL: "clientToServer",
     WORKSPACE_SYMBOL_RESOLVE: "clientToServer",
     WORKSPACE_WILL_CREATE_FILES: "clientToServer",


### PR DESCRIPTION
The only file to review here is `model.py`. Other files are generated.