### PR TITLE
Preserve types for backwards compatibility.

### DIFF
--- a/packages/python/lsprotocol/types.py
+++ b/packages/python/lsprotocol/types.py
@@ -9587,6 +9587,9 @@ class WorkspaceWorkspaceFoldersResponse:
     jsonrpc: str = attrs.field(default="2.0")
 
 
+WorkspaceConfigurationParams = ConfigurationParams
+
+
 @attrs.define
 class WorkspaceConfigurationRequest:
     """The 'workspace/configuration' request is sent from the server to the
@@ -9602,7 +9605,7 @@ class WorkspaceConfigurationRequest:
 
     id: Union[int, str] = attrs.field()
     """The request id."""
-    params: ConfigurationParams = attrs.field()
+    params: WorkspaceConfigurationParams = attrs.field()
     method: str = "workspace/configuration"
     """The method to be invoked."""
     jsonrpc: str = attrs.field(default="2.0")
@@ -13293,6 +13296,7 @@ ALL_TYPES_MAP: Dict[str, Union[type, object]] = {
     "WorkspaceClientCapabilities": WorkspaceClientCapabilities,
     "WorkspaceCodeLensRefreshRequest": WorkspaceCodeLensRefreshRequest,
     "WorkspaceCodeLensRefreshResponse": WorkspaceCodeLensRefreshResponse,
+    "WorkspaceConfigurationParams": WorkspaceConfigurationParams,
     "WorkspaceConfigurationRequest": WorkspaceConfigurationRequest,
     "WorkspaceConfigurationResponse": WorkspaceConfigurationResponse,
     "WorkspaceDiagnosticParams": WorkspaceDiagnosticParams,


### PR DESCRIPTION
This was the old definition (params was composed of two things) the combined type was aliased as `WorkspaceConfigurationParams`:
```json
        {
            "method": "workspace/configuration",
            "result": {
                "kind": "array",
                "element": {
                    "kind": "reference",
                    "name": "LSPAny"
                }
            },
            "messageDirection": "serverToClient",
            "params": {
                "kind": "and",
                "items": [
                    {
                        "kind": "reference",
                        "name": "ConfigurationParams"
                    },
                    {
                        "kind": "reference",
                        "name": "PartialResultParams"
                    }
                ]
            },
            "documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model were the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
        }
```

This is the new definition:
```json
        {
            "method": "workspace/configuration",
            "result": {
                "kind": "array",
                "element": {
                    "kind": "reference",
                    "name": "LSPAny"
                }
            },
            "messageDirection": "serverToClient",
            "params": {
                "kind": "reference",
                "name": "ConfigurationParams"
            },
            "documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model were the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
        }
```
I will preserve the aliasing in lsprotocol in cases like this.

Issue reference:
https://github.com/sublimelsp/LSP-ruff/issues/8
https://github.com/openlawlibrary/pygls/issues/317