### PR TITLE
Introduce lower bound on `attrs` version

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["attrs", "cattrs"]
+dependencies = ["attrs>=21.3.0", "cattrs"]
 
 [project.urls]
 Issues = "https://github.com/microsoft/lsprotocol/issues"


### PR DESCRIPTION
`lsprotocol` uses the `import attrs` API which was only introduced in [`v21.3.0`](https://www.attrs.org/en/stable/changelog.html#id7) .

This PR sets a minimum version for attrs in the python package's `pyproject.toml` to hopefully guard against issues [like this one](https://github.com/swyddfa/esbonio/issues/147#issuecomment-1456102830) in the future.

**Question:** Is it sufficient to rely on the version bound set here to ensure the correct version is also installed for `pygls` and `esbonio`? Or since both downstream packages also `import attrs` themselves, is it more correct to have a version bound set in both `pygls` and `esbonio`? :thinking: 
