### PR TITLE
Use default package location

### DIFF
--- a/azure-pipelines/release-pypi.yml
+++ b/azure-pipelines/release-pypi.yml
@@ -22,7 +22,6 @@ extends:
     pythonVersion: '3.7'
     # We don't ship any built in packages.
     generateNotice: false
-    packageLocation: $(Build.SourcesDirectory)/packages/python/dist
     buildSteps:
       - script: python -m pip install nox
         displayName: Install nox


### PR DESCRIPTION
In https://dev.azure.com/monacotools/Monaco/_build/results?buildId=229140&view=logs&j=9c6ceecd-5363-56f1-0e78-199c2ab175fa&t=dcca69f2-0e61-5643-f82d-945c312c3de6, we see the download task download the artifact to `$(Build.SourcesDirectory)` directly. It then tries to upload `$(Build.SourcesDirectory)/packages/python/dist` to ESRP later but can't find it. The default packageLocation value is `$(Build.SourcesDirectory)/dist`, which would have found the artifact.

A question I have is where does the download task come from? I don't see any download tasks defined under `vscode-engineering/azure-pipelines/pypi-package`, but I do see one defined under https://github.com/microsoft/lsprotocol/blob/790f259e2019b47431f786d11c9b815441218f0c/azure-pipelines/template/publish_pypi.yml#L14. Is that template involved with the run, or is that just a coincidence?

CC @lszomoru