### PR TITLE
Fix TypeScript syntax in docstring

### DIFF
--- a/packages/python/lsprotocol/types.py
+++ b/packages/python/lsprotocol/types.py
@@ -5024,8 +5024,8 @@ class Range:
     For example:
     ```ts
     {
-        start: { line: 5, character: 23 }
-        end : { line 6, character : 0 }
+        start: { line: 5, character: 23 },
+        end : { line: 6, character : 0 },
     }
     ```"""
 


### PR DESCRIPTION
This is a very very small pull request 😉