### PR TITLE
Dev Container for lsprotocol

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:bookworm
+
+RUN apt-get install -y wget bzip2
+
+# Run in silent mode and save downloaded script as anaconda.sh.
+# Run with /bin/bash and run in silent mode to /opt/conda.
+# Also get rid of installation script after finishing.
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2023.07-1-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh
+
+ENV PATH="/opt/conda/bin:$PATH"
+
+# Sudo apt update needs to run in order for installation of fish to work .
+RUN sudo apt update && \
+    sudo apt install fish -y

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
 FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:bookworm
 
-
 # Sudo apt update needs to run in order for installation of fish to work .
 RUN sudo apt update && \
     sudo apt install fish -y

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:bookworm
+FROM mcr.microsoft.com/devcontainers/base:bookworm
 
 # Sudo apt update needs to run in order for installation of fish to work .
 RUN sudo apt update && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,15 +1,5 @@
 FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:bookworm
 
-RUN apt-get install -y wget bzip2
-
-# Run in silent mode and save downloaded script as anaconda.sh.
-# Run with /bin/bash and run in silent mode to /opt/conda.
-# Also get rid of installation script after finishing.
-RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2023.07-1-Linux-x86_64.sh -O ~/anaconda.sh && \
-    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
-    rm ~/anaconda.sh
-
-ENV PATH="/opt/conda/bin:$PATH"
 
 # Sudo apt update needs to run in order for installation of fish to work .
 RUN sudo apt update && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/base:bookworm
+RUN sudo apt update
 
-# Sudo apt update needs to run in order for installation of fish to work .
-RUN sudo apt update && \
-    sudo apt install fish -y
+# Pyenv installation of Python versions is missing below packages.
+RUN sudo apt install libbz2-dev libncurses5-dev libffi-dev libreadline-dev libsqlite3-dev liblzma-dev -y
+
+# Install fish.
+RUN sudo apt install fish -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
-	"name": "Python 3",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
-	"features": {
+	"name": "LSP Dev Container",
+	"build": {
+        "dockerfile": "./Dockerfile",
+        "context": ".."
+    },
+    "features": {
 		"ghcr.io/devcontainers/features/powershell:1": {
 			"version": "latest"
 		},
@@ -20,5 +23,6 @@
 			]
 		}
 	},
-	"postCreateCommand": "python -m pip install nox && python -m pip install -r ./packages/python/requirements.txt -r ./requirements.txt"
+	"onCreateCommand": "bash scripts/onCreateCommand.sh",
+	"postCreateCommand": "bash scripts/postCreateCommand.sh"
 }

--- a/scripts/onCreateCommand.sh
+++ b/scripts/onCreateCommand.sh
@@ -4,12 +4,15 @@
 curl https://pyenv.run | bash
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
 echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-# echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
 export PYENV_ROOT="$HOME/.pyenv"
 command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
 # eval "$(pyenv init -)" Comment this out and DO NOT use shim.
 source ~/.bashrc
+
+# Install Rust and Cargo
+curl https://sh.rustup.rs -sSf | bash -s -- -y
+echo 'source $HOME/.cargo/env' >> ~/.bashrc
 
 # Install Python via pyenv .
 pyenv install 3.8:latest 3.9:latest 3.10:latest 3.11:latest

--- a/scripts/onCreateCommand.sh
+++ b/scripts/onCreateCommand.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Install pyenv and Python versions here to avoid using shim.
+curl https://pyenv.run | bash
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+# echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+
+export PYENV_ROOT="$HOME/.pyenv"
+command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"
+# eval "$(pyenv init -)" Comment this out and DO NOT use shim.
+source ~/.bashrc
+
+# Install Python via pyenv .
+pyenv install 3.8:latest 3.9:latest 3.10:latest 3.11:latest
+
+# Set default Python version to 3.8 .
+pyenv global 3.8.18
+
+# Create Virutal environment.
+pyenv exec python3.8 -m venv .venv
+
+# Activate Virtual environment.
+source /workspaces/lsprotocol/.venv/bin/activate
+

--- a/scripts/postCreateCommand.sh
+++ b/scripts/postCreateCommand.sh
@@ -1,0 +1,3 @@
+source /workspaces/lsprotocol/.venv/bin/activate
+python -m pip install nox
+python -m pip install -r ./packages/python/requirements.txt -r ./requirements.txt


### PR DESCRIPTION
Dev Container support for lsprotocol repository, referencing #234 and adding more things on the way, such as multiple Python versions, cargo, dotnet, venv, requirements, but in a way similar to how dev container is done in the VS Code Python repo: https://github.com/microsoft/vscode-python/pull/21675 

- [x] Add devcontainer.json, onCreateCommand.sh, postCreateCommand.sh appropriately
- [x] Add installation and append to PATH for Cargo, Rust, Python(s)
- [x] Install requirements from postCreateCommand.sh after activating virtual environment

