### PR TITLE
Fixed pyenv version syntax

### DIFF
--- a/generator/model.py
+++ b/generator/model.py
@@ -415,7 +415,7 @@ class ReferenceMapKeyType:
 
 
 def convert_map_key(
-    key_info: Dict[str, Any]
+    key_info: Dict[str, Any],
 ) -> Union[BaseMapKeyType, ReferenceMapKeyType]:
     if key_info["kind"] == "base":
         return BaseMapKeyType(**key_info)

--- a/scripts/onCreateCommand.sh
+++ b/scripts/onCreateCommand.sh
@@ -15,14 +15,13 @@ curl https://sh.rustup.rs -sSf | bash -s -- -y
 echo 'source $HOME/.cargo/env' >> ~/.bashrc
 
 # Install Python via pyenv .
-pyenv install 3.8:latest 3.9:latest 3.10:latest 3.11:latest 3.12:latest
+pyenv install 3.8 3.9 3.10 3.11 3.12
 
 # Set default Python version to 3.8 .
-pyenv global 3.8:latest
+pyenv global 3.8
 
 # Create Virutal environment.
 pyenv exec python3.8 -m venv .venv
 
 # Activate Virtual environment.
 source /workspaces/lsprotocol/.venv/bin/activate
-


### PR DESCRIPTION
The `:latest` syntax used in the  `pyenv` invokation in `onCreateCommand.sh` does not appear to exist. Because of this, the devcontainer fails to build. The fix is to specify the Python versions without patch versions, which makes `pyenv` automatically use the latest version.

Snippet from the log for the previously failing build:

```
pyenv: version `latest' not installed
pyenv: python3.8: command not found

The `python3.8' command exists in these Python versions:
  3.8.18

Note: See 'pyenv help global' for tips on allowing both
      python2 and python3 to be found.
scripts/onCreateCommand.sh: line 27: /workspaces/lsprotocol/.venv/bin/activate: No such file or directory
[1268491 ms] onCreateCommand failed with exit code 1. Skipping any further user-provided commands.
```