### PR TITLE
rust: Fix docs.rs documentation build

### DIFF
--- a/packages/rust/lsprotocol/Cargo.toml
+++ b/packages/rust/lsprotocol/Cargo.toml
@@ -19,3 +19,6 @@ serde_json = "1.0.93"
 serde_repr = "0.1.10"
 url = {version = "2.3.1", features = ["serde"]}
 rust_decimal = "1.29.1"
+
+[package.metadata.docs.rs]
+features = ["proposed"]


### PR DESCRIPTION
https://docs.rs/crate/lsprotocol/1.0.0-alpha.3 does not currently work, because the docs are built without 'proposed' feature enabled. In order to fix the docs page we'll still have to cut a new release though.
